### PR TITLE
chore: cleanup ugly logs

### DIFF
--- a/dank_mids/requests.py
+++ b/dank_mids/requests.py
@@ -407,7 +407,7 @@ class _Batch(_RequestMeta[List[RPCResponse]], Iterable[_Request]):
         elif any(err in f"{e}".lower() for err in constants.RETRY_ERRS):
             # TODO: use these exceptions to optimize for the user's node
             logger.debug('Dank too loud. Bisecting batch and retrying.')
-        elif isinstance(e, BadResponse) and ('invalid request' in f"{e}" or 'Parse error' in f"{e}"):
+        elif isinstance(e, BadResponse) and ('invalid request' in f"{e}" or 'Parse error' in f"{e}" or 'invalid opcode: SHR' in f"{e}"):
             pass
         elif "error processing call Revert" not in f"{e}" and "429" not in f"{e}" and "resource not found" not in f"{e}":
             logger.warning(f"unexpected {e.__class__.__name__}: {e}")


### PR DESCRIPTION
if one call in a multicall reverted with a particular revert string it made ugly logs but no problems. now it makes neither.