### PR TITLE
feat: smaller contract call

### DIFF
--- a/dank_mids/brownie_patch/types.py
+++ b/dank_mids/brownie_patch/types.py
@@ -1,15 +1,33 @@
 
-from typing import Any, Dict, Generic, Optional, TypeVar, Union
+import functools
+from decimal import Decimal
+from typing import Any, Awaitable, Callable, Dict, Generic, Optional, TypeVar, Union
 
+from brownie.typing import AccountsType
+from brownie.convert.utils import build_function_selector, build_function_signature
 from brownie.network.contract import ContractCall, ContractTx, OverloadedMethod
+from eth_abi.exceptions import InsufficientDataBytes
+from web3 import Web3
+
+from dank_mids import ENVIRONMENT_VARIABLES as ENVS
 
 _EVMType = TypeVar("_EVMType")
 
 ContractMethod = Union[ContractCall, ContractTx, OverloadedMethod]
 
+@functools.lru_cache(maxsize=None)
+class FunctionABI:
+    """A singleton to hold function signatures, since we only really need one copy of each func sig in memory."""
+    __slots__ = "abi", "input_sig", "signature"
+    def __init__(self, **abi: Any):
+        self.abi = abi
+        self.input_sig = build_function_signature(abi)
+        self.signature = build_function_selector(abi)
 
-class _DankMethodMixin(Generic[_EVMType]):
-    """A mixin class that gives brownie objects async support"""
+
+class _DankMethod(Generic[_EVMType]):
+    """A mixin class that gives brownie objects async support and reduces memory usage"""
+    __slots__ = "_address", "_abi", "_name", "_owner", "natspec", "encode_input", "decode_input"
     async def __await__(self):
         """Asynchronously call the contract method without arguments at the latest block and await the result."""
         return self.coroutine().__await__()
@@ -31,13 +49,99 @@ class _DankMethodMixin(Generic[_EVMType]):
         Returns:
             - Whatever the node sends back as the output for this contract method.
         """
+        if override:
+            raise ValueError("Cannot use state override with `coroutine`.")
+        async with ENVS.BROWNIE_ENCODER_SEMAPHORE[block_identifier]:
+            data = await self.encode_input(self, self._len_inputs, self._prep_request_data, *args)
+            async with ENVS.BROWNIE_CALL_SEMAPHORE[block_identifier]:
+                output = await self._web3.eth.call({"to": self._address, "data": data}, block_identifier)
+        try:
+            decoded = await self.decode_output(self, output)
+        except InsufficientDataBytes as e:
+            raise InsufficientDataBytes(str(e), self, self._address, output) from e
+        return decoded if decimals is None else decoded / 10 ** Decimal(decimals)
+    def __init__(
+        self,
+        address: str,
+        abi: Dict,
+        name: str,
+        owner: Optional[AccountsType],
+        natspec: Optional[Dict] = None,
+    ) -> None:
+        self._address = address
+        self._abi = FunctionABI(**{key: abi[key] for key in sorted(abi)})
+        self._name = name
+        self._owner = owner
+        self.natspec = natspec or {}
+        # TODO: refactor this
+        from dank_mids.brownie_patch.call import decode_output, encode_input
+        self.encode_input = encode_input
+        self.decode_output = decode_output
+    @property
+    def abi(self) -> dict:
+        return self._abi.abi
+    @property
+    def signature(self) -> str:
+        return self._abi.signature
+    @property
+    def _input_sig(self) -> str:
+        return self._abi.input_sig
+    @functools.cached_property
+    def _len_inputs(self) -> int:
+        return len(self.abi['inputs'])
+    @functools.cached_property
+    def _skip_decoder_proc_pool(self) -> bool:
+        from dank_mids.brownie_patch.call import _skip_proc_pool
+        return self._address in _skip_proc_pool
+    @functools.cached_property
+    def _web3(cls) -> Web3:
+        from dank_mids import web3
+        return web3
+    @functools.cached_property
+    def _prep_request_data(self) -> Callable[..., Awaitable[bytes]]:
+        from dank_mids.brownie_patch import call
+        if ENVS.OPERATION_MODE.application or self._len_inputs:
+            return call.encode
+        else:
+            return call.__request_data_no_args
 
-class DankContractCall(ContractCall, _DankMethodMixin):
-    """This class serves only to enable proper type checking, you will not encounter a `DankContractCall` instance. Instead, you will have a money-patched `ContractCall`."""
-class DankContractTx(ContractTx, _DankMethodMixin):
-    """This class serves only to enable proper type checking, you will not encounter a `DankContractTx` instance. Instead, you will have a money-patched `ContractTx`."""
-class DankOverloadedMethod(OverloadedMethod, _DankMethodMixin):
-    """This class serves only to enable proper type checking, you will not encounter a `DankOverloadedMethod` instance. Instead, you will have a money-patched `OverloadedMethod`."""
+class DankContractCall(_DankMethod, ContractCall):
+    """
+    A `brownie.network.contract.ContractCall` subclass with async support via the `coroutine` method.
+
+    It uses less memory than a `ContractTx` by using __slots__ along with the `FunctionABI` singleton to hold the function abi and related logic.
+
+    You can await this object directly to call the contract method with no arguments at the latest block.
+    """
+class DankContractTx(_DankMethod, ContractTx):
+    """
+    It's a `brownie.network.contract.ContractTx` object with async support via the `coroutine` method.
+
+    It uses less memory than a `ContractTx` by using __slots__ along with the `FunctionABI` singleton to hold the function abi and related logic.
+
+    You can await this object directly to call the contract method with no arguments at the latest block.
+    """
+
+_NonOverloaded = Union[DankContractCall, DankContractTx]
+
+class DankOverloadedMethod(_DankMethod, OverloadedMethod):
+    """
+    It's a `brownie.network.contract.OverloadedMethod` object with async support via the `coroutine` method.
+
+    It uses less memory than a `OverloadedMethod` by using __slots__ along with the `FunctionABI` singleton to hold the function abi and related logic.
+
+    You can await this object directly to call the contract method with no arguments at the latest block.
+    """
+    def __init__(self, address: str, abi: Dict, name: str, owner: Optional[AccountsType], natspec: Optional[Dict] = None) -> None:
+        _DankMethod().__init__(self, address, abi, name, owner, natspec)
+        self.methods: Dict[, _NonOverloaded] = {}
+    __slots__ = "methods", 
 
 DankContractMethod = Union[DankContractCall, DankContractTx, DankOverloadedMethod]
-"""These classes serve only to enable proper type checking, you will not encounter a `DankContractCall`, `DankContractTx`, or `DankOverloadedMethod` instance. Instead, you will have a money-patched `ContractCall`, `ContractTx`, or `OverloadedMethod`."""
+"""
+These are `ContractMethod` objects with async support via an added `coroutine` method.
+
+They use less memory than `ContractMethod` objects by using `FunctionABI` singleton to hold the function abi and related logic.
+
+You can await this object directly to call the contract method with no arguments at the latest block.
+"""

--- a/dank_mids/brownie_patch/types.py
+++ b/dank_mids/brownie_patch/types.py
@@ -1,7 +1,7 @@
 
 import functools
 from decimal import Decimal
-from typing import Any, Awaitable, Callable, Dict, Generic, Optional, TypeVar, Union
+from typing import Any, Awaitable, Callable, Dict, Generic, Optional, Tuple, TypeVar, Union
 
 from brownie.typing import AccountsType
 from brownie.convert.utils import build_function_selector, build_function_signature
@@ -134,7 +134,7 @@ class DankOverloadedMethod(_DankMethod, OverloadedMethod):
     """
     def __init__(self, address: str, abi: Dict, name: str, owner: Optional[AccountsType], natspec: Optional[Dict] = None) -> None:
         _DankMethod().__init__(self, address, abi, name, owner, natspec)
-        self.methods: Dict[, _NonOverloaded] = {}
+        self.methods: Dict[Tuple[str], _NonOverloaded] = {}
     __slots__ = "methods", 
 
 DankContractMethod = Union[DankContractCall, DankContractTx, DankOverloadedMethod]


### PR DESCRIPTION
we now use a singleton to hold method abi info to reduce memory use significantly when you load a bunch of the same contract