### PR TITLE
feat: remove previously deprecated modules

### DIFF
--- a/dank_mids/executor.py
+++ b/dank_mids/executor.py
@@ -1,6 +1,0 @@
-
-import logging
-logger = logging.getLogger(__name__)
-logger.warning("dank_mids.executor module has been deprecated and will be removed eventually.")
-logger.warning("you can now import what you need from a_sync.primitives module https://github.com/BobTheBuidler/ez-a-sync")
-from a_sync.primitives.executor import *

--- a/dank_mids/semaphore.py
+++ b/dank_mids/semaphore.py
@@ -1,6 +1,0 @@
-
-import logging
-logger = logging.getLogger(__name__)
-logger.warning("dank_mids.semaphore module has been deprecated and will be removed eventually.")
-logger.warning("you can now import what you need from a_sync.primitives module https://github.com/BobTheBuidler/ez-a-sync")
-from a_sync.primitives.locks.semaphore import *


### PR DESCRIPTION
removes `dank_mids.semaphore` and `dank_mids.executor`, both of which have been deprecated for a while