### PR TITLE
fix: define chainstack rate limiting handler for µs denominated wait times

### DIFF
--- a/dank_mids/_exceptions.py
+++ b/dank_mids/_exceptions.py
@@ -108,7 +108,10 @@ class ChainstackRateLimited(BadResponse):
         decimal_string = self.response.error.data['try_again_in']
         if "ms" in decimal_string:
             ms = float(decimal_string[:-2])
-            s = ms / 1000
-            logger.info("rate limited by chainstack, retrying in %sms", s)
-            return s
+            logger.info("rate limited by chainstack, retrying in %sms", ms)
+            return ms / 1000
+        elif "µs" in decimal_string:
+            µs = float(decimal_string[:-2])
+            logger.info("rate limited by chainstack, retrying in %sµs", µs)
+            return µs / 1000000
         raise NotImplementedError(f"must define a handler for decimal_string {decimal_string}")


### PR DESCRIPTION
when chainstack rate limits you it sends back an err message telling you how long to wait. When that error was denominated in µs it would break. now it won't break. 