### PR TITLE
fix: _get_len_for_method internal helper

### DIFF
--- a/dank_mids/_requests.py
+++ b/dank_mids/_requests.py
@@ -169,7 +169,7 @@ def _get_len_for_method(method: str) -> int:
     # NOTE: These are totally arbitrary, used to reduce frequency of giant batches/responses
     if method == "eth_getTransactionReceipt":
         return 5
-    elif any(m in method for m in ["eth_getCode" "eth_getBlockBy", "eth_getTransaction"]):
+    elif method in {"eth_getTransaction", "eth_getCode"} or "eth_getBlockBy" in method:
         return 3
     return 1
 


### PR DESCRIPTION
The logic used to limit the number of eth_getTransaction requests in a batch was incorrectly also limiting the number of eth_getTransactionCount requests