### PR TITLE
fix: missing jsonrpc field required for OP stack clients

### DIFF
--- a/dank_mids/helpers/_session.py
+++ b/dank_mids/helpers/_session.py
@@ -16,7 +16,6 @@ from aiohttp.typedefs import DEFAULT_JSON_DECODER, JSONDecoder
 from aiolimiter import AsyncLimiter
 from async_lru import alru_cache
 from dank_mids import ENVIRONMENT_VARIABLES as ENVS
-from dank_mids.helpers._codec import encode
 from dank_mids.types import JSONRPCBatchResponse, PartialRequest, RawResponse
 
 logger = getLogger("dank_mids.session")
@@ -186,7 +185,7 @@ class DankClientSession(ClientSession):
         data = kwargs.get("data")
         if debug_logs_enabled := _logger_is_enabled_for(DEBUG):
             if isinstance(data, PartialRequest):
-                kwargs["data"] = encode(data)
+                kwargs["data"] = data.data
                 _logger_log(DEBUG, "making request for %s", (data,))
             _logger_log(
                 DEBUG,
@@ -194,7 +193,7 @@ class DankClientSession(ClientSession):
                 (endpoint, args, kwargs),
             )
         elif isinstance(data, PartialRequest):
-            kwargs["data"] = encode(data)
+            kwargs["data"] = data.data
 
         # Try the request until success or 5 failures.
         tried = 0

--- a/dank_mids/types.py
+++ b/dank_mids/types.py
@@ -116,7 +116,7 @@ class PartialRequest(DictStruct, frozen=True, omit_defaults=True, repr_omit_defa
 
     @property
     def data(self) -> bytes:
-        return json.encode(self)
+        return json.encode(self, enc_hook=_encode_hook)
 
 
 class Request(PartialRequest):
@@ -133,7 +133,7 @@ class Request(PartialRequest):
     def data(self) -> bytes:
         # we have to do some hacky stuff because omit_defaults kwarg on PartialRequest
         # is preventing jsonrpc field from being included in the encoded bytes
-        encoded_omit_defaults = json.encode(self)
+        encoded_omit_defaults = json.encode(self, enc_hook=_encode_hook)
         return encoded_omit_defaults[:-1] + b',"jsonrpc":"2.0"}'
     
 

--- a/dank_mids/types.py
+++ b/dank_mids/types.py
@@ -135,7 +135,7 @@ class Request(PartialRequest):
         # is preventing jsonrpc field from being included in the encoded bytes
         encoded_omit_defaults = json.encode(self, enc_hook=_encode_hook)
         return encoded_omit_defaults[:-1] + b',"jsonrpc":"2.0"}'
-    
+
 
 class Error(DictStruct, frozen=True, omit_defaults=True, repr_omit_defaults=True):  # type: ignore [call-arg]
     """

--- a/dank_mids/types.py
+++ b/dank_mids/types.py
@@ -129,6 +129,13 @@ class Request(PartialRequest):
     jsonrpc: Literal["2.0"] = "2.0"
     """The JSON-RPC version, always set to "2.0"."""
 
+    @property
+    def data(self) -> bytes:
+        # we have to do some hacky stuff because omit_defaults kwarg on PartialRequest
+        # is preventing jsonrpc field from being included in the encoded bytes
+        encoded_omit_defaults = json.encode(self)
+        return encoded_omit_defaults[:-1] + b',"jsonrpc":"2.0"}'
+    
 
 class Error(DictStruct, frozen=True, omit_defaults=True, repr_omit_defaults=True):  # type: ignore [call-arg]
     """

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "dank-mids"
-version = "4.20.113"
+version = "4.20.114"
 description = "Multicall batching middleware for asynchronous scripts using web3.py"
 authors = ["BobTheBuidler <bobthebuidlerdefi@gmail.com>"]
 homepage = "https://github.com/BobTheBuidler/dank_mids"


### PR DESCRIPTION
The "jsonrpc" field is required for the OP stack without being required on other chains. Now fixed and working great.