### PR TITLE
feat(mypy): annotate test functions

### DIFF
--- a/tests/test_brownie_patch.py
+++ b/tests/test_brownie_patch.py
@@ -17,7 +17,7 @@ get_dank_contract = dank_mids.Contract.from_explorer
 
 
 @pytest.mark.asyncio_cooperative
-async def test_patch_call():
+async def test_patch_call() -> None:
     # must use from_explorer for gh testing workflow
     weth = get_contract("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
     _patch_call(weth.totalSupply, dank_mids.web3)
@@ -28,7 +28,7 @@ async def test_patch_call():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_gather():
+async def test_gather() -> None:
     # must use from_explorer for gh testing workflow
     weth = get_contract("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
     _patch_call(weth.totalSupply, dank_mids.web3)
@@ -40,7 +40,7 @@ async def test_gather():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_patch_contract_call():
+async def test_patch_contract_call() -> None:
     # specify w3
     weth = dank_mids.patch_contract(
         get_contract("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2"), dank_mids.web3
@@ -55,7 +55,7 @@ async def test_patch_contract_call():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_patch_contract_tx():
+async def test_patch_contract_tx() -> None:
     # must use from_explorer for gh testing workflow
     # dont specify w3
     uni_v3_quoter = dank_mids.patch_contract(
@@ -79,7 +79,7 @@ async def test_patch_contract_tx():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_dank_contract_call():
+async def test_dank_contract_call() -> None:
     dank_weth = get_dank_contract("0xC02aaA39b223FE8D0A0e5C4F27eAD9083C756Cc2")
     assert isinstance(dank_weth, dank_mids.Contract)
     assert isinstance(dank_weth.totalSupply, dank_mids.DankContractCall)
@@ -95,7 +95,7 @@ async def test_dank_contract_call():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_dank_contract_tx():
+async def test_dank_contract_tx() -> None:
     # ContractTx
     # must use from_explorer for gh testing workflow
     uni_v3_quoter = get_dank_contract("0xb27308f9F90D607463bb33eA1BeBb41C27CE5AB6")
@@ -116,7 +116,7 @@ async def test_dank_contract_tx():
     ) == Decimal("31.69438072")
 
 
-def test_call_setup_twice_on_same_web3():
+def test_call_setup_twice_on_same_web3() -> None:
     w3_a = dank_mids.setup_dank_w3_from_sync(brownie.web3)
     w3_a.test = True
     w3_b = dank_mids.setup_dank_w3_from_sync(brownie.web3)
@@ -124,7 +124,7 @@ def test_call_setup_twice_on_same_web3():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_dank_overloaded_method():
+async def test_dank_overloaded_method() -> None:
     curve_factory = dank_mids.Contract.from_abi(
         "Vyper_contract", "0xF98B45FA17DE75FB1aD0e7aFD971b0ca00e379fC", abi=_CURVE_FACTORY_ABI
     )

--- a/tests/test_dank_mids.py
+++ b/tests/test_dank_mids.py
@@ -30,7 +30,7 @@ MULTIBLOCK_WORK = (call_chai(i, height - i) for i in range(1000))
 
 
 @pytest.mark.asyncio_cooperative
-async def test_dank_middleware():
+async def test_dank_middleware() -> None:
     await igather(BIG_WORK)
     controller = instances[chain.id][0]
     cid = controller.call_uid.latest
@@ -56,7 +56,7 @@ async def test_dank_middleware():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_bad_hex_handling():
+async def test_bad_hex_handling() -> None:
     """
     Test the handling of bad hex values in contract calls.
 
@@ -68,7 +68,7 @@ async def test_bad_hex_handling():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_json_batch():
+async def test_json_batch() -> None:
     """
     Test the JSON batch processing functionality.
 
@@ -78,7 +78,7 @@ async def test_json_batch():
     await igather(MULTIBLOCK_WORK)
 
 
-def test_next_cid():
+def test_next_cid() -> None:
     """
     Test the generation of the next call ID.
 
@@ -89,7 +89,7 @@ def test_next_cid():
     assert controller.call_uid.next + 1 == controller.call_uid.next
 
 
-def test_next_mid():
+def test_next_mid() -> None:
     """
     Test the generation of the next request ID.
 
@@ -100,7 +100,7 @@ def test_next_mid():
     assert controller.request_uid.next + 1 == controller.request_uid.next
 
 
-def test_next_bid():
+def test_next_bid() -> None:
     """
     Test the generation of the next multicall ID.
 
@@ -112,7 +112,7 @@ def test_next_bid():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_other_methods():
+async def test_other_methods() -> None:
     """
     Test various other RPC methods.
     """
@@ -127,7 +127,7 @@ async def test_other_methods():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_AttributeDict():
+async def test_AttributeDict() -> None:
     """
     Test the AttributeDict functionality.
 
@@ -139,13 +139,13 @@ async def test_AttributeDict():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_string_block():
+async def test_string_block() -> None:
     with pytest.raises(TypeError):
         await Call(CHAI, "totalSupply()(uint)", block_id="14000000")
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getTransaction_1559():
+async def test_eth_getTransaction_1559() -> None:
     tx_1559 = await dank_web3.eth.get_transaction(
         "0x1540ea6e443ff81570624fe19220507a1d949464b5a012ac110c7e91205c456a"
     )
@@ -153,7 +153,7 @@ async def test_eth_getTransaction_1559():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getTransaction_2930():
+async def test_eth_getTransaction_2930() -> None:
     tx_2930 = await dank_web3.eth.get_transaction(
         "0x3ea6b560065dabfac5218c64fd076ef62ff9d6c08817101e7dbece460eb2c8a5"
     )
@@ -161,7 +161,7 @@ async def test_eth_getTransaction_2930():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getTransaction_7702():
+async def test_eth_getTransaction_7702() -> None:
     tx_7702 = await dank_web3.eth.get_transaction(
         "0xad5cdaffa0901bf3abb63c7bfa0307035aeeb94a2ff27d01d6dc33c3d1b40c8a"
     )
@@ -169,60 +169,60 @@ async def test_eth_getTransaction_7702():
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getBalance_no_block():
+async def test_eth_getBalance_no_block() -> None:
     assert isinstance(await dank_web3.eth.get_balance(CHAI), int)
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getBalance_int_block():
+async def test_eth_getBalance_int_block() -> None:
     assert isinstance(await dank_web3.eth.get_balance(CHAI, 20_000_000), int)
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getBalance_hex_block():
+async def test_eth_getBalance_hex_block() -> None:
     assert isinstance(await dank_web3.eth.get_balance(CHAI, hex(20_000_000)), int)
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getBalance_latest():
+async def test_eth_getBalance_latest() -> None:
     assert isinstance(await dank_web3.eth.get_balance(CHAI, "latest"), int)
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getTransactionCount_no_block():
+async def test_eth_getTransactionCount_no_block() -> None:
     assert isinstance(await dank_web3.eth.get_transaction_count(CHAI), int)
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getTransactionCount_int_block():
+async def test_eth_getTransactionCount_int_block() -> None:
     assert isinstance(await dank_web3.eth.get_transaction_count(CHAI, 20_000_000), int)
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getTransactionCount_hex_block():
+async def test_eth_getTransactionCount_hex_block() -> None:
     assert isinstance(await dank_web3.eth.get_transaction_count(CHAI, hex(20_000_000)), int)
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getTransactionCount_latest():
+async def test_eth_getTransactionCount_latest() -> None:
     assert isinstance(await dank_web3.eth.get_transaction_count(CHAI, "latest"), int)
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getCode_no_block():
+async def test_eth_getCode_no_block() -> None:
     assert isinstance(await dank_web3.eth.get_code(CHAI), HexBytes)
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getCode_int_block():
+async def test_eth_getCode_int_block() -> None:
     assert isinstance(await dank_web3.eth.get_code(CHAI, 20_000_000), HexBytes)
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getCode_hex_block():
+async def test_eth_getCode_hex_block() -> None:
     assert isinstance(await dank_web3.eth.get_code(CHAI, hex(20_000_000)), HexBytes)
 
 
 @pytest.mark.asyncio_cooperative
-async def test_eth_getCode_latest():
+async def test_eth_getCode_latest() -> None:
     assert isinstance(await dank_web3.eth.get_code(CHAI, "latest"), HexBytes)

--- a/tests/test_examples.py
+++ b/tests/test_examples.py
@@ -6,5 +6,5 @@ from dank_mids.brownie_patch.contract import retry_etherscan
 
 @pytest.mark.asyncio_cooperative
 @retry_etherscan
-async def test_dank_brownie_example():
+async def test_dank_brownie_example() -> None:
     await examples.dank_brownie_example._main()


### PR DESCRIPTION
### Motivation

- Add explicit return type annotations to test functions to satisfy typing expectations in the test suite.
- Limit changes to the tests only and avoid addressing other mypy errors or production code.
- Make both async and sync test function signatures explicit for better static analysis and clarity.

### Description

- Annotated test functions in `tests/test_brownie_patch.py`, `tests/test_dank_mids.py`, and `tests/test_examples.py` with `-> None` return types.
- Updated both `async def` and `def` test functions across the three files; no behavioral logic was modified.
- Approximately 30 test functions were annotated across the three files and no other files were changed.

### Testing

- No automated test suite was executed as part of this change.
- No CI or `mypy` runs were performed after applying the annotations.
- Verification is left to repository CI to run full test and type checks.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69663bda04a083318e8b8efb171c312f)