### PR TITLE
ci: narrow build workflow paths

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -12,6 +12,7 @@ on:
       - 'pyproject.toml'
       - 'poetry.lock'
       - 'dank_mids/**/*.py'
+      - 'dank_mids/_vendor/aiolimiter'
       - 'dank_mids/_vendor/aiolimiter/**'
 
 concurrency:


### PR DESCRIPTION
## Summary
- switch Build Mypyc workflow trigger to `paths` allowlist
- scope to workflow/config/dependency files and `dank_mids/**/*.py`

## Testing
- not run (workflow trigger change only)