### PR TITLE
feat(cicd): centralize pytest config

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -82,7 +82,8 @@ jobs:
       - name: Run unit tests
         env:
           PYTEST_DISABLE_PLUGIN_AUTOLOAD: 1
-        run: poetry run pytest -s -v tests/unit
+          PYTEST_ADDOPTS: "-s -v tests/unit"
+        run: poetry run pytest
         shell: bash
 
   integration:
@@ -168,6 +169,7 @@ jobs:
           MAX_RETRIES: 2
           MIN_SLEEP_TIME: 1
           MAX_SLEEP_TIME: 3
-        run: poetry run pytest tests/integration -s -v --asyncio-task-timeout=3600
+          PYTEST_ADDOPTS: "-s -v --asyncio-task-timeout=3600 tests/integration"
+        run: poetry run pytest
         shell: bash
       


### PR DESCRIPTION
## Summary
- move pytest CLI args into workflow env vars
- keep workflows invoking pytest without inline args

## Rationale
- keep pytest behavior consistent while removing inline CLI args from workflows

## Details
- set PYTEST_ADDOPTS per job for unit and integration runs
- run pytest without inline args

## Manual testing
- [ ] not run (not requested)
