### PR TITLE
chore: update AGENTS remote-branch guidance

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,5 +16,6 @@ All agents must follow these rules:
 10) Use one of `paths` or `paths-ignore` in every workflow file to make sure workflows only run when required.
 11) All mypy configuration (flags, overrides, per-module ignores, and file targets) should go in pyproject.toml. Do not split config across CLI args, mypy.ini, setup.cfg, or workflow steps.
 12) Centralize pytest settings (flags, markers, ignore patterns, and targets) in pyproject.toml, pytest.ini, setup.cfg, or tox.ini; workflows/hooks should call pytest without inline args.
+13) If the branch you're assigned to work on is from a remote (ie origin/master or upstream/awesome-feature) you must ensure you fetch and pull from the remote before you begin your work.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary:
- Add guidance in `AGENTS.md` to fetch and update a remote-tracking branch before starting work.

Rationale:
- Ensures changes begin from the latest remote state to avoid stale bases and conflicts.

Details:
- Document the remote-branch update step in `AGENTS.md`.