### PR TITLE
docs: add batching flow diagram to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,47 @@ There are a number of optimizations that went into making Dank the fastest way t
 5. Responses are decoded on a JIT (just-in-time) basis, meaning individual task cancellation works as expected even when response data is received as part of a larger batch. 
 6. more stuff I'll write down later...
 
+### Batching Flow
+
+This diagram shows how requests move from user calls into Dank Mids queues, then through batch execution and response spoofing.
+
+```mermaid
+flowchart TD
+    A[User code\nawait w3.eth.call / other RPC] --> B[DankMiddlewareController.__call__]
+
+    B -->|eth_call| C[eth_call request]
+    B -->|other RPC| D[RPCRequest]
+
+    C -->|multicall compatible| E[pending_eth_calls\n(block -> Multicall)]
+    C -->|no multicall| D
+    D --> F[pending_rpc_calls\n(JSONRPCBatch queue)]
+
+    E --> G[RPCRequest.get_response\ntriggers execute_batch when needed]
+    F --> G
+
+    G --> H[DankMiddlewareController.execute_batch]
+    H --> I[DankBatch\n(multicalls + rpc_calls)]
+    I --> J[DankBatch.coroutines]
+
+    J -->|large multicall| K[Multicall.get_response]
+    J -->|small multicall split| L[JSONRPCBatch]
+    J -->|rpc calls| L
+
+    K --> M[_requester.post\neth_call to multicall contract]
+    M --> N[Multicall.spoof_response\nsplit results to eth_call futures]
+
+    L --> O[JSONRPCBatch.post\nbuild JSON-RPC batch payload]
+    O --> P[_requester.post batch\n+ decode responses]
+    P --> Q[JSONRPCBatch.spoof_response\nmatch by id, resolve futures]
+
+    N --> R[User awaiters resolve]
+    Q --> R
+```
+
+Notes:
+- Batches can start early when the queue is full (`_Batch.append` -> `controller.early_start`).
+- Otherwise, the first waiter to need results will trigger `execute_batch` from `RPCRequest.get_response`.
+
 ### Installation
 
 To install Dank Mids, use pip:


### PR DESCRIPTION
## Summary
Add a README batching flow diagram that visualizes how calls are queued, batched, executed, and resolved.

## Rationale
Make the batching behavior easy to understand without digging through the code.

## Details
- Add a "Batching Flow" section with a Mermaid diagram and notes after "Why is Dank so fast?"

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 PYTEST_ADDOPTS="-p no:cacheprovider" pytest` (fails: missing `ganache-cli`; missing `a_sync`; `DankContractCall` import error from `dank_mids.brownie_patch` compiled module)

## Risk and rollback
- Low, docs-only change. Roll back by reverting the README section or this commit.