### PR TITLE
chore: ignore pytest cache files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@ dist
 env
 dank_mids.egg-info
 .hypothesis
-.pytest_cache
+.pytest_cache/*
 .eggs
 .mypy_cache
 __pycache__


### PR DESCRIPTION
## Summary
- ignore `.pytest_cache/*` in `.gitignore`

## Rationale
- keep local pytest cache artifacts from showing up in `git status`

## Details
- update `.pytest_cache` entry to `.pytest_cache/*`
- Testing: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` (fails: missing `ganache-cli` and missing `a_sync`)
