### PR TITLE
docs: clarify handling of generated artifacts in PRs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -20,5 +20,6 @@ All agents must follow these rules:
 
 ## Repo Behavior Notes
 - `WeakList` uses weakrefs on purpose to avoid keeping abandoned calls alive; empty batches or empty JSON-RPC posts can happen when all queued calls are GC'd or drained, and that is expected. Don't "fix" this by switching to strong refs unless we explicitly change the design.
+- Generated artifacts (`.pyd`, `.so`, `build/**/*.c`, `build/**/*.h`) are produced by mypycify/CI; keep them out of PRs unless explicitly requested. If they show up dirty, discard local changes rather than deleting tracked files.
 
 Reference: https://www.conventionalcommits.org/en/v1.0.0/


### PR DESCRIPTION
Summary
- Documented how to handle generated build artifacts in PRs.

Rationale
- Avoids accidental inclusion/removal of mypycify outputs and keeps reviews focused on source changes.

Details
- Added a Repo Behavior Notes bullet covering `.pyd`, `.so`, and `build/**/*.c|h` artifacts.
- Tests: not run (local pytest currently fails in this environment because `ganache-cli` is missing).