### PR TITLE
fix: surface brownie patch init/import errors

### DIFF
--- a/dank_mids/__init__.py
+++ b/dank_mids/__init__.py
@@ -14,6 +14,13 @@ _BROWNIE_OBJECTS: Final[tuple[str, ...]] = (
     "patch_contract",
 )
 
+_BROWNIE_TYPE_OBJECTS: Final[tuple[str, ...]] = (
+    "DankContractCall",
+    "DankContractMethod",
+    "DankContractTx",
+    "DankOverloadedMethod",
+)
+
 _ALIASES: Final[dict[str, str]] = {
     "web3": "dank_web3",
     "eth": "dank_eth",
@@ -66,7 +73,11 @@ if TYPE_CHECKING:
         DankOverloadedMethod,
     )
     from dank_mids.controller import instances
-    from dank_mids.exceptions import BrownieNotConnectedError
+    from dank_mids.exceptions import (
+        BrownieNotConnectedError,
+        BrowniePatchImportError,
+        BrowniePatchNotInitializedError,
+    )
     from dank_mids.helpers import setup_dank_w3, setup_dank_w3_from_sync
     from dank_mids.middleware import dank_middleware
     from dank_mids.semaphores import BlockSemaphore
@@ -97,9 +108,23 @@ def _ensure_side_effects() -> None:
 
 
 def _raise_brownie_not_connected(name: str, exc: BaseException) -> None:
-    from dank_mids.exceptions import BrownieNotConnectedError
+    from dank_mids.brownie_patch import get_brownie_patch_status
+    from dank_mids.exceptions import (
+        BrownieNotConnectedError,
+        BrowniePatchImportError,
+        BrowniePatchNotInitializedError,
+    )
 
-    raise BrownieNotConnectedError(name) from exc
+    status = get_brownie_patch_status(refresh_connection=True)
+    if status.import_error is not None:
+        raise BrowniePatchImportError(name, status.import_error) from status.import_error
+    if not status.connected:
+        raise BrownieNotConnectedError(name) from exc
+    if not status.initialized:
+        raise BrowniePatchNotInitializedError(name) from exc
+    raise AttributeError(
+        f"brownie patch was initialized but `dank_mids.{name}` was not found"
+    ) from exc
 
 
 def _expose_brownie_objects() -> None:
@@ -116,6 +141,10 @@ def _load_attribute(name: str, *, alias: str | None = None) -> Any:
         module = import_module(module_name)
         value = getattr(module, attr_name)
     except (ImportError, AttributeError) as exc:
+        if name in _BROWNIE_TYPE_OBJECTS and isinstance(exc, ImportError):
+            from dank_mids.exceptions import BrowniePatchImportError
+
+            raise BrowniePatchImportError(alias or name, exc) from exc
         if name in _BROWNIE_OBJECTS:
             _raise_brownie_not_connected(alias or name, exc)
         raise
@@ -136,6 +165,12 @@ def __getattr__(name: str) -> Any:
 
     This function lazily imports attributes on first access to avoid importing heavy
     dependencies or triggering side effects during `import dank_mids`.
+
+    Raises:
+        BrowniePatchImportError: If brownie integration failed to import.
+        BrownieNotConnectedError: If brownie is not connected.
+        BrowniePatchNotInitializedError: If brownie is connected but patch is not initialized.
+        AttributeError: If the attribute is not found.
     """
     if name in _ALIASES:
         return _load_attribute(_ALIASES[name], alias=name)

--- a/dank_mids/brownie_patch/__init__.py
+++ b/dank_mids/brownie_patch/__init__.py
@@ -1,16 +1,63 @@
 # sourcery skip: use-contextlib-suppress
-from dank_mids.brownie_patch.types import (
-    DankContractCall,
-    DankContractMethod,
-    DankContractTx,
-    DankOverloadedMethod,
-)
+from dataclasses import dataclass
+from typing import Optional
+
 from dank_mids.helpers import setup_dank_w3_from_sync
 
-__all__ = ["DankContractCall", "DankContractMethod", "DankContractTx", "DankOverloadedMethod"]
+_BROWNIE_TYPE_NAMES = (
+    "DankContractCall",
+    "DankContractMethod",
+    "DankContractTx",
+    "DankOverloadedMethod",
+)
+__all__ = list(_BROWNIE_TYPE_NAMES)
 
 from dank_mids.eth import DankEth
 from dank_mids.helpers._helpers import DankWeb3
+
+@dataclass(frozen=True)
+class BrowniePatchStatus:
+    connected: bool
+    initialized: bool
+    import_error: Optional[ImportError]
+
+
+@dataclass
+class _BrowniePatchState:
+    import_error: Optional[ImportError] = None
+    connected: bool = False
+    initialized: bool = False
+
+    def status(self) -> BrowniePatchStatus:
+        return BrowniePatchStatus(
+            connected=self.connected,
+            initialized=self.initialized,
+            import_error=self.import_error,
+        )
+
+    def set_brownie_import_error(self, exc: ImportError) -> BrowniePatchStatus:
+        self.import_error = exc
+        self.connected = False
+        self.initialized = False
+        return self.status()
+
+    def set_patch_import_error(self, exc: ImportError) -> BrowniePatchStatus:
+        self.import_error = exc
+        self.initialized = False
+        return self.status()
+
+    def refresh_connection(self) -> None:
+        if self.import_error is not None:
+            return
+        try:
+            from brownie import network
+        except ImportError as exc:
+            self.set_brownie_import_error(exc)
+        else:
+            self.connected = network.is_connected()
+
+
+_STATE = _BrowniePatchState()
 
 dank_web3: DankWeb3
 """
@@ -26,15 +73,57 @@ This is initialized if Brownie is installed and connected when this module is lo
 If Brownie is not installed or not connected to an RPC, this instance will not be available.
 """
 
-# If using dank_mids with brownie, and brownie is connected when this file executes, you will get a 'dank_w3' async web3 instance with Dank Middleware here.
-try:
-    from brownie import network, web3
+def initialize_brownie_patch() -> BrowniePatchStatus:
+    global dank_web3
+    global dank_eth
 
-    if network.is_connected():
+    if _STATE.initialized or _STATE.import_error is not None:
+        return _STATE.status()
+
+    try:
+        from brownie import network, web3
+    except ImportError as exc:
+        return _STATE.set_brownie_import_error(exc)
+
+    _STATE.connected = network.is_connected()
+    if not _STATE.connected:
+        _STATE.initialized = False
+        return _STATE.status()
+
+    try:
         from dank_mids.brownie_patch.contract import Contract, patch_contract
+    except ImportError as exc:
+        return _STATE.set_patch_import_error(exc)
 
-        dank_web3 = setup_dank_w3_from_sync(web3)
-        dank_eth = dank_web3.eth
-        __all__ += ["Contract", "patch_contract", "dank_web3", "dank_eth"]
-except ImportError:
-    pass
+    globals()["Contract"] = Contract
+    globals()["patch_contract"] = patch_contract
+    dank_web3 = setup_dank_w3_from_sync(web3)
+    dank_eth = dank_web3.eth
+    __all__ += ["Contract", "patch_contract", "dank_web3", "dank_eth"]
+    _STATE.initialized = True
+    return _STATE.status()
+
+
+def get_brownie_patch_status(refresh_connection: bool = False) -> BrowniePatchStatus:
+    if refresh_connection:
+        _STATE.refresh_connection()
+    return _STATE.status()
+
+
+def _load_types():
+    from dank_mids.brownie_patch import types as _types
+
+    return _types
+
+
+def __getattr__(name: str):
+    if name in _BROWNIE_TYPE_NAMES:
+        _types = _load_types()
+        value = getattr(_types, name)
+        globals()[name] = value
+        return value
+    raise AttributeError(f"module '{__name__}' has no attribute '{name}'")
+
+
+# If using dank_mids with brownie, and brownie is connected when this file executes, you will get a 'dank_w3' async web3 instance with Dank Middleware here.
+initialize_brownie_patch()

--- a/dank_mids/exceptions.py
+++ b/dank_mids/exceptions.py
@@ -18,5 +18,30 @@ class BrownieNotConnectedError(RuntimeError):
         )
 
 
+class BrowniePatchImportError(ImportError):
+    """
+    :class:`ImportError` raised when brownie integration cannot be imported or initialized.
+    """
+
+    def __init__(self, obj_name: str, exc: ImportError) -> None:
+        super().__init__(
+            f"Failed to import brownie integration while accessing `dank_mids.{obj_name}`: {exc}"
+        )
+        self._original_exception = exc
+
+
+class BrowniePatchNotInitializedError(RuntimeError):
+    """
+    :class:`RuntimeError` raised when brownie is connected but brownie patch was not initialized.
+    """
+
+    def __init__(self, obj_name: str) -> None:
+        super().__init__(
+            "Brownie is connected but dank_mids brownie patch was not initialized. "
+            f"This can happen if `dank_mids` was imported before connecting. "
+            f"Restart the process after connecting to access `dank_mids.{obj_name}`."
+        )
+
+
 class GarbageCollectionError(RuntimeError):
     """Exception raised when an object is garbage collected prematurely."""

--- a/tests/unit/test_brownie_patch_errors.py
+++ b/tests/unit/test_brownie_patch_errors.py
@@ -1,0 +1,260 @@
+import builtins
+import importlib
+import importlib.util
+from pathlib import Path
+import sys
+import types
+
+import pytest
+
+
+def _clear_modules() -> None:
+    for name in list(sys.modules):
+        if name == "brownie" or name.startswith("brownie.") or name.startswith("dank_mids"):
+            sys.modules.pop(name, None)
+
+
+def _load_package(name: str, package_dir: Path) -> types.ModuleType:
+    init_path = package_dir / "__init__.py"
+    spec = importlib.util.spec_from_file_location(
+        name,
+        init_path,
+        submodule_search_locations=[str(package_dir)],
+    )
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load package spec for {name} from {init_path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _load_module(name: str, path: Path) -> types.ModuleType:
+    spec = importlib.util.spec_from_file_location(name, path)
+    if spec is None or spec.loader is None:
+        raise RuntimeError(f"unable to load module spec for {name} from {path}")
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+def _install_logging_stub() -> None:
+    stub = types.ModuleType("dank_mids.logging")
+
+    class _Logger:
+        def exception(self, *args, **kwargs) -> None:
+            return None
+
+    def get_c_logger(name: str) -> _Logger:
+        return _Logger()
+
+    stub.get_c_logger = get_c_logger
+    sys.modules["dank_mids.logging"] = stub
+
+
+def _install_dank_mids_stubs() -> None:
+    _eth_utils = types.ModuleType("dank_mids._eth_utils")
+
+    def patch_eth_utils() -> None:
+        return None
+
+    _eth_utils.patch_eth_utils = patch_eth_utils
+    sys.modules["dank_mids._eth_utils"] = _eth_utils
+
+    controller = types.ModuleType("dank_mids.controller")
+    controller.instances = object()
+    sys.modules["dank_mids.controller"] = controller
+
+    helpers_helpers = types.ModuleType("dank_mids.helpers._helpers")
+
+    class DankWeb3: ...
+
+    helpers_helpers.DankWeb3 = DankWeb3
+    sys.modules["dank_mids.helpers._helpers"] = helpers_helpers
+
+    eth = types.ModuleType("dank_mids.eth")
+
+    class DankEth: ...
+
+    eth.DankEth = DankEth
+    sys.modules["dank_mids.eth"] = eth
+
+    helpers = types.ModuleType("dank_mids.helpers")
+
+    def setup_dank_w3(*args, **kwargs):
+        return None
+
+    def setup_dank_w3_from_sync(*args, **kwargs):
+        class _StubW3:
+            eth = DankEth()
+
+        return _StubW3()
+
+    helpers.setup_dank_w3 = setup_dank_w3
+    helpers.setup_dank_w3_from_sync = setup_dank_w3_from_sync
+    sys.modules["dank_mids.helpers"] = helpers
+
+    middleware = types.ModuleType("dank_mids.middleware")
+    middleware.dank_middleware = object()
+    sys.modules["dank_mids.middleware"] = middleware
+
+    semaphores = types.ModuleType("dank_mids.semaphores")
+
+    class BlockSemaphore: ...
+
+    semaphores.BlockSemaphore = BlockSemaphore
+    sys.modules["dank_mids.semaphores"] = semaphores
+
+    brownie_method = types.ModuleType("dank_mids.brownie_patch._method")
+    from typing import Generic, TypeVar
+
+    _EVMType = TypeVar("_EVMType")
+
+    class _DankMethod: ...
+
+    class _DankMethodMixin(Generic[_EVMType]): ...
+
+    brownie_method._DankMethod = _DankMethod
+    brownie_method._DankMethodMixin = _DankMethodMixin
+    brownie_method._EVMType = _EVMType
+    sys.modules["dank_mids.brownie_patch._method"] = brownie_method
+
+
+def _make_import_blocker(block_name: str):
+    original_import = builtins.__import__
+
+    def _blocked(name, globals=None, locals=None, fromlist=(), level=0):
+        if name == block_name:
+            raise ImportError(f"blocked import: {block_name}")
+        return original_import(name, globals, locals, fromlist, level)
+
+    return _blocked
+
+
+def _install_brownie_package(connected: bool) -> types.ModuleType:
+    brownie = types.ModuleType("brownie")
+    network_mod = types.ModuleType("brownie.network")
+    contract_mod = types.ModuleType("brownie.network.contract")
+    typing_mod = types.ModuleType("brownie.typing")
+
+    network_mod.connected = connected
+
+    def is_connected() -> bool:
+        return network_mod.connected
+
+    network_mod.is_connected = is_connected
+
+    class ContractCall: ...
+
+    class ContractTx: ...
+
+    class OverloadedMethod: ...
+
+    contract_mod.ContractCall = ContractCall
+    contract_mod.ContractTx = ContractTx
+    contract_mod.OverloadedMethod = OverloadedMethod
+
+    typing_mod.AccountsType = object
+
+    network_mod.contract = contract_mod
+    brownie.network = network_mod
+    brownie.web3 = object()
+    brownie.typing = typing_mod
+
+    sys.modules["brownie"] = brownie
+    sys.modules["brownie.network"] = network_mod
+    sys.modules["brownie.network.contract"] = contract_mod
+    sys.modules["brownie.typing"] = typing_mod
+    return network_mod
+
+
+def _reload_dank_mids(monkeypatch, brownie_connected: bool | None = None, import_hook=None):
+    _clear_modules()
+    network_mod = None
+    if brownie_connected is not None:
+        network_mod = _install_brownie_package(brownie_connected)
+    if import_hook is not None:
+        monkeypatch.setattr(builtins, "__import__", import_hook)
+
+    _install_logging_stub()
+    _install_dank_mids_stubs()
+
+    # Load pure-Python modules directly to avoid compiled extensions during tests.
+    root = Path(__file__).resolve().parents[2]
+    package_root = root / "dank_mids"
+    brownie_patch_root = package_root / "brownie_patch"
+
+    dank_pkg = types.ModuleType("dank_mids")
+    dank_pkg.__path__ = [str(package_root)]
+    sys.modules["dank_mids"] = dank_pkg
+
+    brownie_pkg = types.ModuleType("dank_mids.brownie_patch")
+    brownie_pkg.__path__ = [str(brownie_patch_root)]
+    sys.modules["dank_mids.brownie_patch"] = brownie_pkg
+
+    _load_module("dank_mids.exceptions", package_root / "exceptions.py")
+    _load_package("dank_mids.brownie_patch", brownie_patch_root)
+    return _load_package("dank_mids", package_root), network_mod
+
+
+def test_getattr_raises_import_error_for_missing_brownie(monkeypatch) -> None:
+    import_hook = _make_import_blocker("brownie")
+    dank_mids, _ = _reload_dank_mids(monkeypatch, import_hook=import_hook)
+    exc_types = importlib.import_module("dank_mids.exceptions")
+
+    with pytest.raises(exc_types.BrowniePatchImportError) as excinfo:
+        _ = dank_mids.dank_web3
+
+    assert isinstance(excinfo.value.__cause__, ImportError)
+
+
+def test_getattr_raises_not_connected(monkeypatch) -> None:
+    dank_mids, _ = _reload_dank_mids(monkeypatch, brownie_connected=False)
+    exc_types = importlib.import_module("dank_mids.exceptions")
+
+    with pytest.raises(exc_types.BrownieNotConnectedError):
+        _ = dank_mids.dank_web3
+
+
+def test_getattr_raises_not_initialized_when_connected_after_import(monkeypatch) -> None:
+    dank_mids, network = _reload_dank_mids(monkeypatch, brownie_connected=False)
+    exc_types = importlib.import_module("dank_mids.exceptions")
+
+    assert network is not None
+    network.connected = True
+
+    with pytest.raises(exc_types.BrowniePatchNotInitializedError):
+        _ = dank_mids.dank_web3
+
+
+def test_getattr_raises_import_error_when_patch_import_fails(monkeypatch) -> None:
+    import_hook = _make_import_blocker("dank_mids.brownie_patch.contract")
+    dank_mids, _ = _reload_dank_mids(
+        monkeypatch,
+        brownie_connected=True,
+        import_hook=import_hook,
+    )
+    exc_types = importlib.import_module("dank_mids.exceptions")
+
+    with pytest.raises(exc_types.BrowniePatchImportError) as excinfo:
+        _ = dank_mids.dank_web3
+
+    assert isinstance(excinfo.value.__cause__, ImportError)
+
+
+def test_getattr_raises_import_error_for_missing_brownie_types(monkeypatch) -> None:
+    import_hook = _make_import_blocker("brownie")
+    dank_mids, _ = _reload_dank_mids(monkeypatch, import_hook=import_hook)
+    exc_types = importlib.import_module("dank_mids.exceptions")
+
+    with pytest.raises(exc_types.BrowniePatchImportError) as excinfo:
+        _ = dank_mids.DankContractCall
+
+    assert isinstance(excinfo.value.__cause__, ImportError)
+
+
+def test_getattr_resolves_brownie_types(monkeypatch) -> None:
+    dank_mids, _ = _reload_dank_mids(monkeypatch, brownie_connected=False)
+
+    assert isinstance(dank_mids.DankContractCall, type)


### PR DESCRIPTION
## Summary
- Lazy-load Brownie type access so `import dank_mids` does not require Brownie installed.
- Surface brownie patch status errors with explicit exceptions.

## Rationale
- Avoid hard import-time dependency on Brownie while preserving clear failure reasons.

## Details
- `dank_mids.__getattr__` resolves Brownie attributes lazily and raises `BrowniePatchImportError`/`BrowniePatchNotInitializedError` where appropriate.
- `dank_mids.brownie_patch` tracks patch status and initializes patch exports when Brownie is connected.
- Added tests covering missing brownie, not-connected, and not-initialized scenarios.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 ./.venv/bin/pytest tests/unit/test_brownie_patch_errors.py`
