### PR TITLE
chore(cicd): dedupe setup-python cache steps

### DIFF
--- a/.github/actions/setup-python-cache/action.yml
+++ b/.github/actions/setup-python-cache/action.yml
@@ -1,0 +1,18 @@
+name: Setup Python With Pip Cache
+description: Set up Python with pip caching and dependency-based cache keys.
+inputs:
+  python-version:
+    description: Python version to install.
+    required: true
+  cache-dependency-path:
+    description: Paths used to compute the pip cache key.
+    required: true
+runs:
+  using: composite
+  steps:
+    - name: Set up Python
+      uses: actions/setup-python@v6
+      with:
+        python-version: ${{ inputs.python-version }}
+        cache: pip
+        cache-dependency-path: ${{ inputs.cache-dependency-path }}

--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -48,50 +48,45 @@ jobs:
 
       # Python 3.10
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.10"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.10)
         run: make mypyc
 
       # Python 3.11
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.11"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.11)
         run: make mypyc
 
       # Python 3.12
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.12"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.12)
         run: make mypyc
 
       # Python 3.13
       - name: Set up Python 3.13
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.13"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.13)
         run: make mypyc
 
       # Python 3.14
       - name: Set up Python 3.14
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.14"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.14)
         run: make mypyc
@@ -165,50 +160,45 @@ jobs:
 
       # Python 3.10
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.10"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.10)
         run: make mypyc
 
       # Python 3.11
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.11"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.11)
         run: make mypyc
 
       # Python 3.12
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.12"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.12)
         run: make mypyc
 
       # Python 3.13
       - name: Set up Python 3.13
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.13"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.13)
         run: make mypyc
 
       # Python 3.14
       - name: Set up Python 3.14
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.14"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.14)
         run: make mypyc
@@ -251,50 +241,45 @@ jobs:
 
       # Python 3.10
       - name: Set up Python 3.10
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.10"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.10)
         run: make mypyc
 
       # Python 3.11
       - name: Set up Python 3.11
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.11"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.11)
         run: make mypyc
 
       # Python 3.12
       - name: Set up Python 3.12
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.12"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.12)
         run: make mypyc
 
       # Python 3.13
       - name: Set up Python 3.13
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.13"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.13)
         run: make mypyc
 
       # Python 3.14
       - name: Set up Python 3.14
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.14"
-          cache: pip
           cache-dependency-path: requirements-build.txt
       - name: Run Mypyc (3.14)
         run: make mypyc

--- a/.github/workflows/mypy.yaml
+++ b/.github/workflows/mypy.yaml
@@ -28,10 +28,9 @@ jobs:
         persist-credentials: false
         
     - name: Setup Python (faster than using Python container)
-      uses: actions/setup-python@v6
+      uses: ./.github/actions/setup-python-cache
       with:
         python-version: ${{ matrix.pyversion }}
-        cache: pip
         cache-dependency-path: |
             pyproject.toml
             poetry.lock

--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -37,10 +37,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python (faster than using Python container)
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: ${{ matrix.pyversion }}
-          cache: pip
           cache-dependency-path: |
               pyproject.toml
               poetry.lock
@@ -114,10 +113,9 @@ jobs:
           persist-credentials: false
 
       - name: Setup Python (faster than using Python container)
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: ${{ matrix.pyversion }}
-          cache: pip
           cache-dependency-path: |
               pyproject.toml
               poetry.lock

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -19,10 +19,9 @@ jobs:
           submodules: true
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: ./.github/actions/setup-python-cache
         with:
           python-version: "3.12"
-          cache: pip
           cache-dependency-path: |
             pyproject.toml
             poetry.lock


### PR DESCRIPTION
Summary:
- add a local composite action to wrap setup-python with pip cache settings
- replace duplicated setup-python cache blocks in build, pytest, mypy, and release workflows

Rationale:
- reduce copy/paste while keeping cache config consistent across CI

Details:
- new action `.github/actions/setup-python-cache/action.yml` accepts `python-version` and `cache-dependency-path`
- workflows now call the local action; deploy-docs remains unchanged
- Tests: `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 .venv/bin/pytest tests/unit` (fails: `ModuleNotFoundError: No module named 'dank_mids.helpers._codec'; 'dank_mids.helpers' is not a package`)