### PR TITLE
chore: bootstrap pre-commit check-yaml and contributor setup docs

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,5 @@
+repos:
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.6.0
+    hooks:
+      - id: check-yaml

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,57 @@
+# Contributing
+
+## Pre-commit
+
+This repository uses `pre-commit` for local checks before commit.
+
+### Install
+
+Use one of the following:
+
+```bash
+pipx install pre-commit
+```
+
+```bash
+python -m pip install pre-commit
+```
+
+### Setup
+
+Run this once after cloning:
+
+```bash
+pre-commit install
+```
+
+### Daily usage
+
+Run checks on changed files:
+
+```bash
+pre-commit run
+```
+
+Run checks for all tracked files:
+
+```bash
+pre-commit run --all-files
+```
+
+Run only YAML validation:
+
+```bash
+pre-commit run check-yaml --all-files
+```
+
+### Updating hooks
+
+To update hook revisions:
+
+```bash
+pre-commit autoupdate
+```
+
+### Notes
+
+`check-yaml` runs in strict mode in this repo. YAML files with custom tags may fail validation unless explicitly handled in a future config update.

--- a/README.md
+++ b/README.md
@@ -70,6 +70,11 @@ To install Dank Mids, use pip:
 
 `pip install dank-mids`
 
+### Development and Contributing
+
+This repository uses `pre-commit` for local commit-time checks.
+Setup and usage instructions live in [`CONTRIBUTING.md`](./CONTRIBUTING.md).
+
 ### Benchmark
 
 We've included a [benchmark script](./examples/benchmark.py) that compares the time it takes to fetch the pool tokens (token0 and token1) for each pool on Sushiswap on Ethereum mainnet. To run it, first install the repo with `poetry install` and then run the benchmark with `brownie run examples/benchmark`.


### PR DESCRIPTION
## Summary
- add root `.pre-commit-config.yaml` with first hook rollout (`check-yaml`) in strict mode
- add `CONTRIBUTING.md` as the canonical setup/usage guide for pre-commit
- add a short `README.md` pointer to `CONTRIBUTING.md` for contributor workflow details

## Rationale
- establish an initial pre-commit baseline with minimal scope and low risk
- catch YAML syntax issues before CI and reduce avoidable workflow/config churn
- keep contributor setup instructions centralized in one source of truth

## Details
- `.pre-commit-config.yaml` uses `pre-commit/pre-commit-hooks` @ `v4.6.0` with only `check-yaml`
- `CONTRIBUTING.md` documents install, one-time setup, daily usage, targeted hook execution, and hook updates
- `README.md` now links contributors to `CONTRIBUTING.md`

### Validation
Executed locally in a clean branch worktree:
- `.venv/bin/pip check`
- `.venv/bin/pre-commit run check-yaml --all-files`
- `.venv/bin/pre-commit run --all-files`

All commands passed.

Pytest was intentionally not run for this docs/config-only change per explicit scope direction.