### PR TITLE
fix(cicd): keep mypyc deps canonical and add safe make test bootstrap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,17 @@
-.PHONY: docs mypy mypyc mypyc-deps
+.PHONY: docs mypy mypyc mypyc-deps pytest test test-deps
 
 PYTHON ?= python
 MYPYC_DEPS_FILE = requirements-build.txt
+PYTEST_CMD ?= pytest
+TEST_DEPS = \
+	"eth-brownie==1.22.0.dev2" \
+	"pytest==6.2.5" \
+	"pytest-asyncio-cooperative==0.40.0" \
+	"pytest-cov==6.3.0" \
+	"pytest-sugar==1.1.1" \
+	"types-aiofiles==25.1.0.20251011" \
+	"importlib-resources>=6.4.0" \
+	"setuptools<81"
 
 mypy:
 	mypy ./dank_mids --pretty --ignore-missing-imports --show-error-codes --show-error-context --no-warn-no-return
@@ -53,6 +63,19 @@ mypyc: mypyc-deps
 		dank_mids/middleware.py \
 		dank_mids/stats/__init__.py \
 		--strict --pretty --disable-error-code=unused-ignore
+
+test-deps:
+	$(PYTHON) -m pip install -U $(TEST_DEPS)
+
+pytest: test-deps
+	PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PYTEST_CMD)
+
+test:
+	@set -e; \
+	trap 'git submodule update --init --recursive --checkout --force dank_mids/_vendor/aiolimiter >/dev/null 2>&1 || true' EXIT; \
+	$(MAKE) update-aiolimiter; \
+	$(MAKE) mypyc; \
+	$(MAKE) pytest
 
 
 # Vendoring


### PR DESCRIPTION
## Summary
- Keep `mypyc-deps` scoped to the canonical build-deps file (`requirements-build.txt`) so mypyc compile does not pick up Brownie/dev typing surface.
- Add `test-deps`, `pytest`, and `test` Make targets.
- Add an EXIT trap in `make test` that restores `dank_mids/_vendor/aiolimiter` to the repo-pinned submodule state on both success and failure.

## Rationale
- The regression came from expanding `mypyc-deps` to install Brownie/dev dependencies, which changes type surfaces and causes strict mypyc errors in `dank_mids/brownie_patch/*`.
- We still need a clean-env `make test` entrypoint without duplicating the canonical mypyc build deps source.
- `update-aiolimiter` can leave submodule working state dirty; cleanup must be automatic and reliable.

## Details
- `Makefile`
  - Added: `PYTEST_CMD ?= pytest`
  - Added: `TEST_DEPS` list for test/runtime deps only
  - Added: `test-deps` target (`pip install -U $(TEST_DEPS)`)
  - Added: `pytest` target (`PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 $(PYTEST_CMD)`) depending on `test-deps`
  - Added: `test` target:
    - wraps execution with `trap 'git submodule update --init --recursive --checkout --force dank_mids/_vendor/aiolimiter ...' EXIT`
    - runs `update-aiolimiter`, then `mypyc`, then `pytest`
- `mypyc-deps` remains unchanged and canonical:
  - `$(PYTHON) -m pip install -r requirements-build.txt`

### Validation (clean env, Python 3.13)
- `python -m pip check` -> `No broken requirements found.`
- `make mypyc` -> success (`exit 0`)
- `python -m pip check` after mypyc -> `No broken requirements found.`
- `make test PYTEST_CMD=/bin/true` in a fresh venv -> success (`exit 0`)
- `make test PYTHON=/nonexistent PYTEST_CMD=/bin/true` -> fails as expected, and cleanup still runs
- `git status --short dank_mids/_vendor/aiolimiter` after both success/failure checks -> empty (no lingering aiolimiter diff)
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest` -> fails in this env during collection due missing `ganache-cli` (expected environment prerequisite), unrelated to Makefile change