### PR TITLE
fix(cicd): route build mypyc through a dedicated CI runner script

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -8,6 +8,7 @@ on:
     paths:
       - '.github/actions/setup-python-cache/action.yml'
       - '.github/workflows/build.yaml'
+      - 'scripts/run_mypyc_build.py'
       - '.gitmodules'
       - 'Makefile'
       - 'pyproject.toml'
@@ -51,7 +52,7 @@ jobs:
             poetry.lock
 
       - name: Run Mypyc
-        run: make mypyc
+        run: python scripts/run_mypyc_build.py
 
       - name: Upload build artifacts
         uses: actions/upload-artifact@v6

--- a/scripts/run_mypyc_build.py
+++ b/scripts/run_mypyc_build.py
@@ -1,0 +1,104 @@
+#!/usr/bin/env python3
+"""Build-workflow-only mypyc runner."""
+
+from __future__ import annotations
+
+import argparse
+import os
+import pathlib
+import shlex
+import subprocess
+from typing import Iterable
+
+ROOT = pathlib.Path(__file__).resolve().parents[1]
+MYPYC_DEPS_FILE = ROOT / "requirements-build.txt"
+
+MYPYC_TARGETS = [
+    "dank_mids/_batch.py",
+    "dank_mids/_demo_mode.py",
+    "dank_mids/_envs.py",
+    "dank_mids/_eth_utils.py",
+    "dank_mids/_exceptions.py",
+    "dank_mids/_tasks.py",
+    "dank_mids/_uid.py",
+    "dank_mids/_vendor/aiolimiter/src",
+    "dank_mids/_web3/abi.py",
+    "dank_mids/_web3/formatters.py",
+    "dank_mids/brownie_patch/__init__.py",
+    "dank_mids/brownie_patch/_abi.py",
+    "dank_mids/brownie_patch/call.py",
+    "dank_mids/brownie_patch/overloaded.py",
+    "dank_mids/brownie_patch/types.py",
+    "dank_mids/constants.py",
+    "dank_mids/controller.py",
+    "dank_mids/ENVIRONMENT_VARIABLES.py",
+    "dank_mids/helpers/__init__.py",
+    "dank_mids/helpers/_codec.py",
+    "dank_mids/helpers/_errors.py",
+    "dank_mids/helpers/_gather.py",
+    "dank_mids/helpers/_rate_limit.py",
+    "dank_mids/helpers/_requester.py",
+    "dank_mids/helpers/_weaklist.py",
+    "dank_mids/helpers/batch_size.py",
+    "dank_mids/helpers/hashing.py",
+    "dank_mids/helpers/lru_cache.py",
+    "dank_mids/helpers/method.py",
+    "dank_mids/lock.py",
+    "dank_mids/logging.py",
+    "dank_mids/middleware.py",
+    "dank_mids/stats/__init__.py",
+]
+
+MYPYC_FLAGS = ["--strict", "--pretty", "--disable-error-code=unused-ignore"]
+
+
+def build_install_command(python_executable: str) -> list[str]:
+    return [python_executable, "-m", "pip", "install", "-r", str(MYPYC_DEPS_FILE)]
+
+
+def build_mypyc_command() -> list[str]:
+    return ["mypyc", *MYPYC_TARGETS, *MYPYC_FLAGS]
+
+
+def run_checked(command: list[str], *, env: dict[str, str] | None = None) -> None:
+    subprocess.run(command, check=True, cwd=ROOT, env=env)
+
+
+def format_command(command: Iterable[str]) -> str:
+    return " ".join(shlex.quote(part) for part in command)
+
+
+def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument(
+        "--python",
+        default=os.environ.get("PYTHON", "python"),
+        help="Python executable used for dependency install.",
+    )
+    parser.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Print commands without executing them.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = parse_args(argv)
+    install_command = build_install_command(args.python)
+    mypyc_command = build_mypyc_command()
+
+    if args.dry_run:
+        print(format_command(install_command))
+        print(format_command(mypyc_command))
+        return 0
+
+    run_checked(install_command)
+    compile_env = os.environ.copy()
+    compile_env["MYPYC_STRICT_DUNDER_TYPING"] = "1"
+    run_checked(mypyc_command, env=compile_env)
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/unit/test_run_mypyc_build.py
+++ b/tests/unit/test_run_mypyc_build.py
@@ -1,0 +1,49 @@
+from __future__ import annotations
+
+import importlib.util
+import os
+from pathlib import Path
+
+MODULE_PATH = Path(__file__).resolve().parents[2] / "scripts" / "run_mypyc_build.py"
+SPEC = importlib.util.spec_from_file_location("run_mypyc_build", MODULE_PATH)
+assert SPEC is not None and SPEC.loader is not None
+run_mypyc_build = importlib.util.module_from_spec(SPEC)
+SPEC.loader.exec_module(run_mypyc_build)
+
+
+def test_build_install_command_uses_requirements_file() -> None:
+    command = run_mypyc_build.build_install_command("python3")
+
+    assert command[:4] == ["python3", "-m", "pip", "install"]
+    assert command[-2] == "-r"
+    assert command[-1].endswith("requirements-build.txt")
+
+
+def test_build_mypyc_command_contains_targets_and_flags() -> None:
+    command = run_mypyc_build.build_mypyc_command()
+
+    assert command[0] == "mypyc"
+    assert "dank_mids/_batch.py" in command
+    assert "dank_mids/stats/__init__.py" in command
+    assert "--strict" in command
+    assert "--pretty" in command
+    assert "--disable-error-code=unused-ignore" in command
+
+
+def test_main_runs_install_then_compile(monkeypatch) -> None:
+    calls: list[tuple[list[str], dict[str, str] | None]] = []
+
+    def fake_run(command: list[str], *, env: dict[str, str] | None = None) -> None:
+        calls.append((command, env))
+
+    monkeypatch.setattr(run_mypyc_build, "run_checked", fake_run)
+
+    rc = run_mypyc_build.main(["--python", "py"])
+
+    assert rc == 0
+    assert len(calls) == 2
+    assert calls[0][0][:2] == ["py", "-m"]
+    assert calls[1][0][0] == "mypyc"
+    assert calls[1][1] is not None
+    assert calls[1][1]["MYPYC_STRICT_DUNDER_TYPING"] == "1"
+    assert calls[1][1]["PATH"] == os.environ["PATH"]


### PR DESCRIPTION
## Summary
- replace the `make mypyc` step in `.github/workflows/build.yaml` with `python scripts/run_mypyc_build.py`
- add `scripts/run_mypyc_build.py` as a build-only CI runner for dependency install + mypyc compile
- add focused unit tests for the runner script behavior
- keep release verification untouched on `scripts/check_mypyc_wheel.py`

## Rationale
- isolates build compile execution from Make invocation while keeping release verification on its own existing script path
- preserves the approved scope: only touchpoints related to the CI `make mypyc` call
- adds coverage for command construction/order so CI runner changes are safer to iterate

## Details
- workflow trigger paths now include `scripts/run_mypyc_build.py` so PRs modifying the runner still trigger build CI
- runner behavior mirrors current Makefile `mypyc` target semantics:
  - installs `requirements-build.txt`
  - runs `mypyc` with the same target list and flags
  - sets `MYPYC_STRICT_DUNDER_TYPING=1` for the compile command
- tests added in `tests/unit/test_run_mypyc_build.py`:
  - requirements install command composition
  - mypyc command target/flag composition
  - main execution order and strict env injection
