### PR TITLE
fix: add dev-only make test flow with EXIT cleanup

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,8 @@
-.PHONY: docs mypy mypyc mypyc-deps
+.PHONY: docs mypy mypyc mypyc-deps pytest test test-clean
 
 PYTHON ?= python
 MYPYC_DEPS_FILE = requirements-build.txt
+PYTEST_CMD ?= PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest
 
 mypy:
 	mypy ./dank_mids --pretty --ignore-missing-imports --show-error-codes --show-error-context --no-warn-no-return
@@ -53,6 +54,25 @@ mypyc: mypyc-deps
 		dank_mids/middleware.py \
 		dank_mids/stats/__init__.py \
 		--strict --pretty --disable-error-code=unused-ignore
+
+pytest:
+	$(PYTEST_CMD)
+
+test:
+	@set -e; \
+	trap '$(MAKE) --no-print-directory test-clean' EXIT; \
+	$(MAKE) --no-print-directory update-aiolimiter; \
+	$(MAKE) --no-print-directory mypyc; \
+	$(MAKE) --no-print-directory pytest
+
+test-clean:
+	git submodule update --init --recursive --checkout --force dank_mids/_vendor/aiolimiter ||:
+	git ls-files -z -- 'dank_mids/**/*.so' 'dank_mids/**/*.pyd' 'build/**/*.c' 'build/**/*.h' \
+		| xargs -0r git restore --source=HEAD --worktree --staged -- ||:
+	git clean -fd -- build ||:
+	find dank_mids -type f \( -name '*.so' -o -name '*.pyd' \) ! -path 'dank_mids/_vendor/*' -print0 \
+		| xargs -0r sh -c 'for f do git ls-files --error-unmatch "$$f" >/dev/null 2>&1 || rm -f "$$f"; done' _ ||:
+	git clean -f -- '*__mypyc*.so' '*__mypyc*.pyd' ||:
 
 
 # Vendoring


### PR DESCRIPTION
## Summary
- add dev-only `pytest`, `test`, and `test-clean` targets in `Makefile`
- make `test` run in one shell with `set -e` and an EXIT trap registered before setup
- run `update-aiolimiter -> mypyc -> pytest` in `test`
- always run teardown via `test-clean` on success or failure

## Rationale
- local dev test runs should be able to prepare aiolimiter/mypyc state and still return the repo to pinned state even when `mypyc` or `pytest` fails
- cleanup must remain narrowly scoped to generated artifact paths and aiolimiter submodule state
- CI split remains intact and untouched (`scripts/run_mypyc_build.py` remains CI-only)

## Details
- `test-clean` now restores `dank_mids/_vendor/aiolimiter` to repo-pinned commit with:
  - `git submodule update --init --recursive --checkout --force dank_mids/_vendor/aiolimiter`
- `test-clean` reverts/removes mypyc artifacts from scoped paths only:
  - restore tracked `dank_mids/**/*.so`, `dank_mids/**/*.pyd`, `build/**/*.c`, `build/**/*.h`
  - clean untracked `build/`
  - remove untracked `dank_mids/**/*.so|*.pyd` (excluding `_vendor`)
  - remove untracked root `*__mypyc*.so|*.pyd`
- no workflow changes and no new aiolimiter alias target were introduced

## Verification
- `make test PYTEST_CMD=true` (cleanup executed; no aiolimiter/artifact drift from run)
- `make test PYTEST_CMD=false` (cleanup executed; no aiolimiter/artifact drift from run)
- `PATH=.venv/bin:$PATH PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit -q`