### PR TITLE
fix(cicd): prevent aggregate aiolimiter no-op commit failures

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -129,7 +129,7 @@ jobs:
 
       - name: Check for changes (aiolimiter)
         run: |
-          if [[ -n $(git status --porcelain) ]]; then
+          if [[ -n $(git -C dank_mids/_vendor/aiolimiter status --porcelain) ]]; then
             echo "aiolimiter_changes_detected=true" >> $GITHUB_ENV
           else
             echo "aiolimiter_changes_detected=false" >> $GITHUB_ENV
@@ -145,6 +145,10 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           git remote set-url origin https://x-access-token:${GH_TOKEN}@github.com/BobTheBuidler/aiolimiter.git
           git add .
+          if git diff --cached --quiet; then
+            echo "No aiolimiter changes to commit."
+            exit 0
+          fi
           git commit -m "chore: add artifacts for dank-mids"
           git pull --rebase
           git push origin HEAD:mypyc
@@ -164,5 +168,9 @@ jobs:
           git config --local user.email "github-actions[bot]@users.noreply.github.com"
           make update-aiolimiter
           git add dank_mids/_vendor/aiolimiter
+          if git diff --cached --quiet; then
+            echo "No aiolimiter submodule pointer changes to commit."
+            exit 0
+          fi
           git commit -m "chore: update aiolimiter submodule pointer"
           git push


### PR DESCRIPTION
## Summary
- Fixes `aggregate-ubuntu` false-positive aiolimiter change detection that could trigger a commit step when the aiolimiter repo had no changes.
- Adds no-op-safe commit guards so CI skips commit/push cleanly when nothing is staged.
- Preserves the CI compile runner split (`python scripts/run_mypyc_build.py`) unchanged.

## Rationale
- The workflow was checking aiolimiter changes from repo root (`git status --porcelain`) but committing inside `dank_mids/_vendor/aiolimiter`.
- That mismatch can set `aiolimiter_changes_detected=true` even when the submodule working tree is clean, causing `git commit` to fail with "nothing to commit".
- Adding staged-diff guards also prevents adjacent no-op commit failures in the submodule pointer update job.

## Details
- Updated aiolimiter change detection to use:
  - `git -C dank_mids/_vendor/aiolimiter status --porcelain`
- In `Commit and push aiolimiter changes`, added guard:
  - `git add .` then `git diff --cached --quiet` -> exit 0 on no-op.
- In `update-submodule-pointer`, added guard:
  - `git add dank_mids/_vendor/aiolimiter` then `git diff --cached --quiet` -> exit 0 on no-op.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit/test_run_mypyc_build.py -q`