### PR TITLE
fix(cicd): centralize pytest flags in suite config files

### DIFF
--- a/.github/workflows/pytest.yaml
+++ b/.github/workflows/pytest.yaml
@@ -7,6 +7,7 @@ on:
       - '.github/actions/setup-python-cache/action.yml'
       - '**.py'
       - '**.so'
+      - '**/pytest.ini'
       - '**/pytest.yaml'
       - 'poetry.lock'
   workflow_dispatch:
@@ -83,7 +84,7 @@ jobs:
       - name: Run unit tests
         env:
           PYTEST_DISABLE_PLUGIN_AUTOLOAD: 1
-        run: poetry run pytest -s -v tests/unit
+        run: poetry run pytest tests/unit
         shell: bash
 
   integration:
@@ -169,5 +170,5 @@ jobs:
           MAX_RETRIES: 2
           MIN_SLEEP_TIME: 1
           MAX_SLEEP_TIME: 3
-        run: poetry run pytest tests/integration -s -v --asyncio-task-timeout=3600
+        run: poetry run pytest tests/integration
         shell: bash

--- a/tests/integration/pytest.ini
+++ b/tests/integration/pytest.ini
@@ -1,0 +1,3 @@
+[pytest]
+addopts = -s -v
+asyncio_task_timeout = 3600

--- a/tests/unit/pytest.ini
+++ b/tests/unit/pytest.ini
@@ -1,0 +1,2 @@
+[pytest]
+addopts = -s -v


### PR DESCRIPTION
## Summary
- Added `tests/unit/pytest.ini` with `addopts = -s -v`.
- Added `tests/integration/pytest.ini` with `addopts = -s -v` and `asyncio_task_timeout = 3600`.
- Updated `.github/workflows/pytest.yaml` to call pytest without inline CLI flags.
- Added `**/pytest.ini` to `pull_request.paths` so pytest config changes trigger this workflow.

## Rationale
- Keep pytest defaults centralized in suite config files instead of duplicating flags in workflow commands.
- Preserve existing CI behavior while aligning with repo policy that workflows should invoke pytest without inline args.

## Details
- Unit job command changed from `poetry run pytest -s -v tests/unit` to `poetry run pytest tests/unit`.
- Integration job command changed from `poetry run pytest tests/integration -s -v --asyncio-task-timeout=3600` to `poetry run pytest tests/integration`.
- Existing env vars, matrix dimensions, provider matrix, and cache configuration were left unchanged.

## Testing
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/unit` (from `.venv`) -> **fails** with pre-existing `tests/unit/test_jsonrpc_batch_response.py::test_spoof_response_by_id_matches_and_skips_falsey` (`ModuleNotFoundError: 'dank_mids.helpers' is not a package`). Reproduced on clean baseline with this patch stashed.
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest tests/integration -q` -> **cannot run locally** in this environment: `ganache-cli` is missing (`FileNotFoundError` during `tests/integration/conftest.py`).
- Compiled extension verification: `python - <<'PY'\nimport dank_mids._batch as m\nprint(m.__file__)\nPY` -> loaded `.so` extension (`dank_mids/_batch.cpython-313-x86_64-linux-gnu.so`).