### PR TITLE
perf: use StringWriter for stack logging

### DIFF
--- a/build/__native_ef7a1095370504e32934.h
+++ b/build/__native_ef7a1095370504e32934.h
@@ -3,6 +3,7 @@
 #include <Python.h>
 #include <CPy.h>
 #include "random/librt_random.h"
+#include "strings/librt_strings.h"
 #include "time/librt_time.h"
 #include "vecs/librt_vecs.h"
 #ifndef MYPYC_DECLARED_tuple_T3CIO

--- a/build/__native_internal_ef7a1095370504e32934.h
+++ b/build/__native_internal_ef7a1095370504e32934.h
@@ -6,7 +6,7 @@
 
 int CPyGlobalsInit(void);
 
-extern PyObject *CPyStatics[1511];
+extern PyObject *CPyStatics[1510];
 extern const char * const CPyLit_Str[];
 extern const char * const CPyLit_Bytes[];
 extern const char * const CPyLit_Int[];
@@ -300,9 +300,9 @@ extern int CPyExec_dank_mids___lock(PyObject *module);
 extern PyObject *CPyInit_dank_mids___lock(void);
 extern PyObject *CPyInitOnly_dank_mids___lock(void);
 extern PyObject *CPyStatic_logging___globals;
-extern CPyModule *CPyModule_io;
 extern CPyModule *CPyModule_traceback;
 extern CPyModule *CPyModule_contextlib;
+extern CPyModule *CPyModule_librt___strings;
 extern int CPyExec_dank_mids___logging(PyObject *module);
 extern PyObject *CPyInit_dank_mids___logging(void);
 extern PyObject *CPyInitOnly_dank_mids___logging(void);
@@ -1682,7 +1682,6 @@ extern CPyTagged CPyStatic_logging___WARN;
 extern CPyTagged CPyStatic_logging___INFO;
 extern CPyTagged CPyStatic_logging___DEBUG;
 extern CPyTagged CPyStatic_logging___NOTSET;
-extern PyObject *CPyStatic_logging___StringIO;
 extern PyObject *CPyStatic_logging___print_stack;
 extern PyObject *CPyStatic_logging____nameToLevel;
 extern PyObject *CPyStatic_logging____acquireLock;

--- a/dank_mids/logging.py
+++ b/dank_mids/logging.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
 
-import io
 import logging
 import os
 import sys
@@ -9,6 +8,8 @@ from collections.abc import Iterator, Mapping
 from contextlib import contextmanager
 from types import FrameType
 from typing import Any, Final, cast
+
+from librt.strings import StringWriter
 
 Level = int
 CallerInfo = tuple[str, int, str, str | None]
@@ -22,8 +23,6 @@ INFO: Final = logging.INFO
 DEBUG: Final = logging.DEBUG
 NOTSET: Final = logging.NOTSET
 
-
-StringIO: Final = io.StringIO
 
 print_stack: Final = traceback.print_stack
 
@@ -228,13 +227,12 @@ class CLogger(logging.Logger):
                 continue
             sinfo = None
             if stack_info:
-                sio = StringIO()
+                sio = StringWriter()
                 sio.write("Stack (most recent call last):\n")
                 print_stack(frame, file=sio)
                 sinfo = sio.getvalue()
                 if sinfo[-1] == "\n":
                     sinfo = sinfo[:-1]
-                sio.close()
             rv = (co_filename, cast(int, frame.f_lineno), co.co_name, sinfo)
             break
         return rv

--- a/tests/unit/test_logging_stringwriter.py
+++ b/tests/unit/test_logging_stringwriter.py
@@ -1,0 +1,16 @@
+from dank_mids.logging import get_c_logger
+
+
+def _find_caller_with_stack_info() -> str:
+    logger = get_c_logger("dank_mids.tests.logging")
+    _filename, _line, _function, stack_info = logger.findCaller(stack_info=True)
+    assert stack_info is not None
+    return stack_info
+
+
+def test_find_caller_stack_info_is_plain_stack_text() -> None:
+    stack_info = _find_caller_with_stack_info()
+
+    assert stack_info.startswith("Stack (most recent call last):")
+    assert "_find_caller_with_stack_info" in stack_info
+    assert stack_info[-1] != "\n"


### PR DESCRIPTION
## Summary
Replace the stack-info buffer in `CLogger.findCaller()` with `librt.strings.StringWriter`.

## Rationale
`CLogger` is mypyc-compiled, and stack-info logging currently builds its stack text through a Python string buffer. `StringWriter` gives the compiled path a faster writer while preserving the existing plain-text stack output.

## Details
- Swap stack-info buffering from `StringIO` to `StringWriter`.
- Keep the current `findCaller()` behavior and return shape unchanged.
- Add unit coverage proving `stack_info=True` still returns plain stack text, includes the caller frame, and does not keep the trailing newline.
- Leave broader logging semantics and `LogRecord` construction untouched for a separate follow-up.