### PR TITLE
fix(logging): match py310 findCaller public frame parity

### DIFF
--- a/build/__native_dank_mids.h
+++ b/build/__native_dank_mids.h
@@ -61,13 +61,6 @@ typedef struct tuple_T2II {
 } tuple_T2II;
 #endif
 
-#ifndef MYPYC_DECLARED_tuple_T1O
-#define MYPYC_DECLARED_tuple_T1O
-typedef struct tuple_T1O {
-    PyObject *f0;
-} tuple_T1O;
-#endif
-
 #ifndef MYPYC_DECLARED_tuple_T0
 #define MYPYC_DECLARED_tuple_T0
 typedef struct tuple_T0 {
@@ -154,6 +147,13 @@ typedef struct tuple_T4OIOO {
     PyObject *f2;
     PyObject *f3;
 } tuple_T4OIOO;
+#endif
+
+#ifndef MYPYC_DECLARED_tuple_T1O
+#define MYPYC_DECLARED_tuple_T1O
+typedef struct tuple_T1O {
+    PyObject *f0;
+} tuple_T1O;
 #endif
 
 typedef struct {

--- a/build/__native_internal_dank_mids.h
+++ b/build/__native_internal_dank_mids.h
@@ -6,7 +6,7 @@
 
 int CPyGlobalsInit(void);
 
-extern PyObject *CPyStatics[1533];
+extern PyObject *CPyStatics[1525];
 extern const char * const CPyLit_Str[];
 extern const char * const CPyLit_Bytes[];
 extern const char * const CPyLit_Int[];
@@ -112,7 +112,6 @@ extern CPyModule *CPyModule_functools;
 extern CPyModule *CPyModule_heapq;
 extern CPyModule *CPyModule_itertools;
 extern CPyModule *CPyModule_types;
-extern CPyModule *CPyModule_pathlib;
 extern int CPyExec_dank_mids____vendor___aiolimiter___src___aiolimiter___leakybucket(PyObject *module);
 extern PyObject *CPyInit_dank_mids____vendor___aiolimiter___src___aiolimiter___leakybucket(void);
 extern PyObject *CPyInitOnly_dank_mids____vendor___aiolimiter___src___aiolimiter___leakybucket(void);

--- a/dank_mids/logging.py
+++ b/dank_mids/logging.py
@@ -351,10 +351,18 @@ def _find_caller_frame(stacklevel: int) -> FrameType | None:
 
 
 def _find_caller_frame_py310(stacklevel: int) -> FrameType | None:
+    f = _find_caller_frame(stacklevel)
+    if f is None or not f.f_code.co_name.startswith("_"):
+        return f
+
+    # Helper-stack calls still need py3.10 stdlib findCaller frame parity.
     try:
-        f = logging.currentframe()
+        f = sys._getframe(2)
     except ValueError:
-        f = sys._getframe()
+        try:
+            f = logging.currentframe()
+        except ValueError:
+            f = sys._getframe()
     if f is not None and _is_logging_caller_internal_frame(f):
         f = f.f_back
     orig_f = f


### PR DESCRIPTION
## Summary

Fix Python 3.10 `CLogger.findCaller` parity so compiled dank-mids logging reports the same public caller frame as stdlib `logging.Logger`.

## Rationale

The Python 3.10 caller-walk path was starting from `logging.currentframe()`, which could leave the compiled logging helper boundary misaligned with stdlib behavior. Starting from the expected public frame boundary keeps emitted log records consistent with stdlib caller metadata.

## Details

- Start the Python 3.10 caller lookup with `sys._getframe(2)`.
- Preserve fallback behavior for runtimes where frame lookup raises `ValueError`.
- Regenerate the tracked mypyc C artifact for review.

## Testing

- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest tests/unit/logging tests/compiled_imports/test_compiled_imports.py`