### PR TITLE
test(cicd): clarify compiled runtime contract

### DIFF
--- a/.github/workflows/build-test.yaml
+++ b/.github/workflows/build-test.yaml
@@ -214,7 +214,7 @@ jobs:
 
       - name: Run compiled import audit
         env:
-          DANK_MIDS_COMPILED_IMPORT_MODE: source-tree
+          DANK_MIDS_COMPILED_IMPORT_LOCATION: source-tree
           PYTHONFAULTHANDLER: 1
           PYTEST_DISABLE_PLUGIN_AUTOLOAD: 1
           TYPEDENVS_SHUTUP: 1

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -92,7 +92,7 @@ jobs:
           CIBW_SKIP: "pp* *-musllinux_* *-win32"
           CIBW_TEST_COMMAND: "pytest {project}/tests/compiled_imports/test_compiled_imports.py"
           CIBW_TEST_ENVIRONMENT: >
-            DANK_MIDS_COMPILED_IMPORT_MODE=installed-wheel
+            DANK_MIDS_COMPILED_IMPORT_LOCATION=installed-wheel
             PYTHONFAULTHANDLER=1
             PYTEST_DISABLE_PLUGIN_AUTOLOAD=1
             TYPEDENVS_SHUTUP=1

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,6 +2,8 @@
 
 All agents must follow these rules:
 
+dank-mids is always compiled. PyPI wheels are compiled, setup compiles the project, and tests/CI must validate compiled extensions. Do not invent or reason from an interpreted `.py` runtime path; tracked `.py` files are mypyc source inputs.
+
 1) Sandbox runs may block Unix socketpair wakeups; rerun asyncio/threaded failures outside the sandbox before declaring repo, mypyc, or Python regressions.
 2) Fully test your changes before submitting a PR (run the full suite or all relevant tests): `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 pytest <files>`
 3) PR titles must be descriptive and follow Conventional Commits-style prefixes:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,5 +1,16 @@
 # Contributing
 
+## Compiled Runtime Contract
+
+dank-mids is validated as a compiled mypyc package. Treat tracked `.py` files as
+mypyc source inputs for the compiled runtime, not as a separate supported direct
+`.py` execution path.
+
+CI validates compiled source-tree artifacts copied into the checkout, and
+release tests validate compiled wheel artifacts imported from the installed
+wheel. Terms such as `source-tree` describe where native `.so`/`.pyd` artifacts
+are imported from; they do not imply direct `.py` execution.
+
 ## Pre-commit
 
 This repository uses `pre-commit` for local checks before commit.

--- a/tests/compiled_imports/test_compiled_imports.py
+++ b/tests/compiled_imports/test_compiled_imports.py
@@ -1,3 +1,11 @@
+"""Audit that dank-mids imports as compiled native mypyc artifacts.
+
+dank-mids is validated as a compiled mypyc package. The ``source-tree``
+location means native ``.so``/``.pyd`` artifacts copied into the checkout, and
+the ``installed-wheel`` location means native artifacts imported from an
+installed wheel. This audit never validates direct execution of ``.py`` sources.
+"""
+
 from __future__ import annotations
 
 import importlib
@@ -25,6 +33,10 @@ compiled_module_names = _mypyc_targets.compiled_module_names
 extension_suffix = _mypyc_targets.extension_suffix
 
 MODULE_NAMES = compiled_module_names(REPO_ROOT)
+COMPILED_IMPORT_LOCATION_ENV = "DANK_MIDS_COMPILED_IMPORT_LOCATION"
+LEGACY_COMPILED_IMPORT_MODE_ENV = "DANK_MIDS_COMPILED_IMPORT_MODE"
+SOURCE_TREE_LOCATION = "source-tree"
+INSTALLED_WHEEL_LOCATION = "installed-wheel"
 
 
 def _path_resolves_to_repo(path_entry: str) -> bool:
@@ -36,16 +48,24 @@ def _path_resolves_to_repo(path_entry: str) -> bool:
 
 
 def _prepare_imports() -> None:
-    mode = os.getenv("DANK_MIDS_COMPILED_IMPORT_MODE", "source-tree")
-    if mode == "source-tree":
+    location = os.getenv(COMPILED_IMPORT_LOCATION_ENV) or os.getenv(
+        LEGACY_COMPILED_IMPORT_MODE_ENV,
+        SOURCE_TREE_LOCATION,
+    )
+    if location == SOURCE_TREE_LOCATION:
         sys.path[:] = [path_entry for path_entry in sys.path if path_entry != str(REPO_ROOT)]
         sys.path.insert(0, str(REPO_ROOT))
-    elif mode == "installed-wheel":
+    elif location == INSTALLED_WHEEL_LOCATION:
         sys.path[:] = [
             path_entry for path_entry in sys.path if not _path_resolves_to_repo(path_entry)
         ]
     else:
-        pytest.fail(f"unsupported compiled import mode: {mode!r}")
+        pytest.fail(
+            f"unsupported compiled artifact location: {location!r}; expected "
+            f"{SOURCE_TREE_LOCATION!r} or {INSTALLED_WHEEL_LOCATION!r}. These values select "
+            "where native .so/.pyd artifacts are imported from, not direct "
+            ".py-source execution."
+        )
     importlib.invalidate_caches()
     # Pytest collection may already hold references to imported dank_mids classes.
     # Do not unload mypyc modules in-process; stale source imports fail below.

--- a/tests/unit/logging/test_public_contract.py
+++ b/tests/unit/logging/test_public_contract.py
@@ -1,9 +1,24 @@
 from __future__ import annotations
 
+import importlib.machinery
 import logging
 from collections.abc import Callable
 
+from dank_mids import logging as dank_logging
 from dank_mids.logging import CLogger, get_c_logger, use_c_logger_class
+
+_NATIVE_SUFFIXES = tuple(
+    dict.fromkeys((*importlib.machinery.EXTENSION_SUFFIXES, ".so", ".pyd"))
+)
+
+
+def test_logging_parity_suite_runs_against_compiled_logging_extension() -> None:
+    module_file = getattr(dank_logging, "__file__", None)
+
+    assert isinstance(module_file, str) and module_file.endswith(_NATIVE_SUFFIXES), (
+        "logging parity tests must run against compiled dank_mids.logging; "
+        "build/download source-tree extensions before running this suite."
+    )
 
 
 def test_get_c_logger_returns_c_logger(logger_name_prefix: str) -> None:


### PR DESCRIPTION
## Summary
- Clarifies that dank-mids validates compiled native runtime behavior and removes source/interpreted-runtime ambiguity for future agents.

## Rationale
- Prevents agents from inferring an interpreted .py runtime path in this mypyc package.

## Details
- Adds one concise compiled-runtime paragraph near the top of AGENTS.md.