### PR TITLE
test: preserve DankEth middleware behavior

### DIFF
--- a/tests/unit/_jsonrpc.py
+++ b/tests/unit/_jsonrpc.py
@@ -1,0 +1,98 @@
+from __future__ import annotations
+
+import json
+import threading
+from collections.abc import Iterator
+from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
+from typing import Any
+
+import pytest
+from web3._utils.rpc_abi import RPC
+from web3.providers.async_base import AsyncBaseProvider
+from web3.types import RPCEndpoint, RPCResponse
+
+
+class AsyncProvider(AsyncBaseProvider):
+    endpoint_uri = "https://node.example"
+
+    def __init__(
+        self,
+        endpoint_uri: str = "https://node.example",
+        response: RPCResponse | None = None,
+    ) -> None:
+        super().__init__()
+        self.endpoint_uri = endpoint_uri
+        self.response = response
+        self.calls: list[tuple[RPCEndpoint, Any]] = []
+
+    async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
+        self.calls.append((method, params))
+        if self.response is None:
+            raise AssertionError(f"unexpected provider request: {method} {params!r}")
+        return self.response
+
+    async def is_connected(self, show_traceback: bool = False) -> bool:
+        return True
+
+
+class JsonRpcServer(ThreadingHTTPServer):
+    calls: list[tuple[str, Any]]
+    errors: dict[str, dict[str, Any]]
+    results: dict[str, Any]
+
+
+class _JsonRpcHandler(BaseHTTPRequestHandler):
+    def do_POST(self) -> None:
+        content_length = int(self.headers.get("Content-Length", "0"))
+        payload = json.loads(self.rfile.read(content_length))
+        is_batch = isinstance(payload, list)
+        requests = payload if is_batch else [payload]
+        server = self.server
+        assert isinstance(server, JsonRpcServer)
+        responses = [self._handle_request(server, request) for request in requests]
+        body = json.dumps(responses if is_batch else responses[0]).encode()
+
+        self.send_response(200)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Content-Length", str(len(body)))
+        self.end_headers()
+        self.wfile.write(body)
+
+    def log_message(self, _format: str, *args: Any) -> None:
+        return None
+
+    @staticmethod
+    def _handle_request(server: JsonRpcServer, request: dict[str, Any]) -> dict[str, Any]:
+        method = request["method"]
+        params = request.get("params", [])
+        server.calls.append((method, params))
+        response = {"jsonrpc": "2.0", "id": request.get("id")}
+        if error := server.errors.get(method):
+            response["error"] = error
+        else:
+            response["result"] = server.results[method]
+        return response
+
+
+def server_endpoint(server: JsonRpcServer) -> str:
+    return f"http://127.0.0.1:{server.server_port}"
+
+
+@pytest.fixture
+def jsonrpc_server() -> Iterator[JsonRpcServer]:
+    server = JsonRpcServer(("127.0.0.1", 0), _JsonRpcHandler)
+    server.calls = []
+    server.errors = {}
+    server.results = {
+        RPC.eth_chainId: "0x1",
+        RPC.web3_clientVersion: "pytest/test",
+        RPC.eth_blockNumber: "0x7b",
+    }
+    thread = threading.Thread(target=server.serve_forever, daemon=True)
+    thread.start()
+    try:
+        yield server
+    finally:
+        server.shutdown()
+        thread.join(timeout=5)
+        server.server_close()

--- a/tests/unit/test_controller_cache.py
+++ b/tests/unit/test_controller_cache.py
@@ -1,104 +1,24 @@
 import asyncio
-import json
 import threading
 from collections.abc import Iterator
-from http.server import BaseHTTPRequestHandler, ThreadingHTTPServer
 from queue import Queue
 from typing import Any, TypeAlias
 
 import pytest
 from web3 import AsyncWeb3
-from web3._utils.rpc_abi import RPC
-from web3.providers.async_base import AsyncBaseProvider
-from web3.types import RPCEndpoint, RPCResponse
 
 import dank_mids.helpers._controllers as controller_cache_module
 import dank_mids.middleware as middleware
+from tests.unit._jsonrpc import AsyncProvider, JsonRpcServer, jsonrpc_server, server_endpoint
 
 
 ControllerCache: TypeAlias = dict[tuple[AsyncWeb3, threading.Thread], Any]
 
 
-class _AsyncProvider(AsyncBaseProvider):
-    endpoint_uri = "https://node.example"
-
-    def __init__(self, endpoint_uri: str = "https://node.example") -> None:
-        super().__init__()
-        self.endpoint_uri = endpoint_uri
-
-    async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
-        raise AssertionError(f"unexpected provider request: {method} {params!r}")
-
-    async def is_connected(self, show_traceback: bool = False) -> bool:
-        return True
-
-
-class _JsonRpcServer(ThreadingHTTPServer):
-    calls: list[tuple[str, Any]]
-    errors: dict[str, dict[str, Any]]
-    results: dict[str, Any]
-
-
-class _JsonRpcHandler(BaseHTTPRequestHandler):
-    def do_POST(self) -> None:
-        content_length = int(self.headers.get("Content-Length", "0"))
-        payload = json.loads(self.rfile.read(content_length))
-        is_batch = isinstance(payload, list)
-        requests = payload if is_batch else [payload]
-        server = self.server
-        assert isinstance(server, _JsonRpcServer)
-        responses = [self._handle_request(server, request) for request in requests]
-        body = json.dumps(responses if is_batch else responses[0]).encode()
-
-        self.send_response(200)
-        self.send_header("Content-Type", "application/json")
-        self.send_header("Content-Length", str(len(body)))
-        self.end_headers()
-        self.wfile.write(body)
-
-    def log_message(self, _format: str, *args: Any) -> None:
-        return None
-
-    @staticmethod
-    def _handle_request(server: _JsonRpcServer, request: dict[str, Any]) -> dict[str, Any]:
-        method = request["method"]
-        params = request.get("params", [])
-        server.calls.append((method, params))
-        response = {"jsonrpc": "2.0", "id": request.get("id")}
-        if error := server.errors.get(method):
-            response["error"] = error
-        else:
-            response["result"] = server.results[method]
-        return response
-
-
-def _server_endpoint(server: _JsonRpcServer) -> str:
-    return f"http://127.0.0.1:{server.server_port}"
-
-
 def _async_w3(endpoint_uri: str) -> AsyncWeb3:
-    async_w3 = AsyncWeb3(_AsyncProvider(endpoint_uri))
+    async_w3 = AsyncWeb3(AsyncProvider(endpoint_uri))
     async_w3.middleware_onion.clear()
     return async_w3
-
-
-@pytest.fixture
-def jsonrpc_server() -> Iterator[_JsonRpcServer]:
-    server = _JsonRpcServer(("127.0.0.1", 0), _JsonRpcHandler)
-    server.calls = []
-    server.errors = {}
-    server.results = {
-        RPC.eth_chainId: "0x1",
-        RPC.web3_clientVersion: "pytest/test",
-    }
-    thread = threading.Thread(target=server.serve_forever, daemon=True)
-    thread.start()
-    try:
-        yield server
-    finally:
-        server.shutdown()
-        thread.join(timeout=5)
-        server.server_close()
 
 
 @pytest.fixture
@@ -112,10 +32,10 @@ def controller_cache() -> Iterator[ControllerCache]:
 
 def test_controller_cache_reuses_web3_thread_pair(
     controller_cache: ControllerCache,
-    jsonrpc_server: _JsonRpcServer,
+    jsonrpc_server: JsonRpcServer,
 ) -> None:
     async def run() -> None:
-        async_w3 = _async_w3(_server_endpoint(jsonrpc_server))
+        async_w3 = _async_w3(server_endpoint(jsonrpc_server))
 
         first = await middleware.DankMiddleware(async_w3).async_wrap_make_request(
             async_w3.provider.make_request
@@ -132,10 +52,10 @@ def test_controller_cache_reuses_web3_thread_pair(
 
 def test_controller_cache_keeps_web3_thread_pairs_distinct(
     controller_cache: ControllerCache,
-    jsonrpc_server: _JsonRpcServer,
+    jsonrpc_server: JsonRpcServer,
 ) -> None:
     async def run() -> None:
-        endpoint_uri = _server_endpoint(jsonrpc_server)
+        endpoint_uri = server_endpoint(jsonrpc_server)
         async_w3 = _async_w3(endpoint_uri)
         other_async_w3 = _async_w3(endpoint_uri)
         result_queue: Queue[tuple[Any, threading.Thread, BaseException | None]] = Queue()
@@ -181,10 +101,10 @@ def test_controller_cache_keeps_web3_thread_pairs_distinct(
 
 def test_web3_v7_middleware_class_reuses_controller_for_web3_thread_pair(
     controller_cache: ControllerCache,
-    jsonrpc_server: _JsonRpcServer,
+    jsonrpc_server: JsonRpcServer,
 ) -> None:
     async def run() -> None:
-        endpoint_uri = _server_endpoint(jsonrpc_server)
+        endpoint_uri = server_endpoint(jsonrpc_server)
         async_w3 = _async_w3(endpoint_uri)
         other_async_w3 = _async_w3(endpoint_uri)
 

--- a/tests/unit/test_dank_eth_direct_dispatch.py
+++ b/tests/unit/test_dank_eth_direct_dispatch.py
@@ -2,14 +2,14 @@ import asyncio
 import inspect
 from dataclasses import dataclass
 from types import SimpleNamespace
-from typing import Any
+from typing import Any, ClassVar
 
 import pytest
 from web3 import AsyncWeb3
 from web3._utils.rpc_abi import RPC
 from web3.eth import AsyncEth
 from web3.method import Method
-from web3.providers.async_base import AsyncBaseProvider
+from web3.middleware.base import Web3Middleware
 from web3.types import RPCEndpoint, RPCResponse
 
 import dank_mids
@@ -18,20 +18,11 @@ import dank_mids.helpers._controllers as controller_cache_module
 import dank_mids.helpers._helpers as helpers
 import dank_mids.middleware as middleware
 from dank_mids.eth import DankEth
+from tests.unit._jsonrpc import AsyncProvider
 
 
 ACCOUNT = "0x0000000000000000000000000000000000000001"
 OTHER_ACCOUNT = "0x0000000000000000000000000000000000000002"
-
-
-class _AsyncProvider(AsyncBaseProvider):
-    endpoint_uri = "https://node.example"
-
-    async def make_request(self, method: RPCEndpoint, params: Any) -> RPCResponse:
-        raise AssertionError(f"unexpected provider request: {method} {params!r}")
-
-    async def is_connected(self, show_traceback: bool = False) -> bool:
-        return True
 
 
 class _NoopAsyncContext:
@@ -56,7 +47,7 @@ class _ProcessParamsCase:
 
 
 def _async_w3() -> AsyncWeb3:
-    async_w3 = AsyncWeb3(_AsyncProvider())
+    async_w3 = AsyncWeb3(AsyncProvider())
     async_w3.middleware_onion.clear()
     return async_w3
 
@@ -228,6 +219,40 @@ def test_middleware_route_only_request_function_reaches_dank_controller(
             assert calls == [(request_func, RPC.eth_blockNumber, ())]
         finally:
             _clear_controller_cache()
+
+    asyncio.run(run())
+
+
+def test_dank_eth_get_block_number_preserves_non_dank_async_middleware() -> None:
+    class RewriteBlockNumberMiddleware(Web3Middleware):
+        observed_methods: ClassVar[list[RPCEndpoint]] = []
+
+        async def async_request_processor(
+            self,
+            method: RPCEndpoint,
+            params: Any,
+        ) -> tuple[RPCEndpoint, Any]:
+            self.observed_methods.append(method)
+            return method, params
+
+        async def async_response_processor(
+            self,
+            method: RPCEndpoint,
+            response: RPCResponse,
+        ) -> RPCResponse:
+            if method == RPC.eth_blockNumber:
+                return {**response, "result": "0x7c"}
+            return response
+
+    async def run() -> None:
+        provider = AsyncProvider(response={"jsonrpc": "2.0", "id": 1, "result": "0x7b"})
+        async_w3 = AsyncWeb3(provider)
+        async_w3.middleware_onion.clear()
+        async_w3.middleware_onion.add(RewriteBlockNumberMiddleware)
+
+        assert await DankEth(async_w3).get_block_number() == "0x7c"
+        assert provider.calls == [(RPC.eth_blockNumber, ())]
+        assert RewriteBlockNumberMiddleware.observed_methods == [RPC.eth_blockNumber]
 
     asyncio.run(run())
 


### PR DESCRIPTION
Extract shared JSON-RPC unit-test helpers so follow-up fixes stay focused.

Add a guardrail proving DankEth still honors non-Dank async middleware.