### PR TITLE
test(logging): expose py310 findCaller public frame drift

### DIFF
--- a/tests/unit/logging/parity/test_caller.py
+++ b/tests/unit/logging/parity/test_caller.py
@@ -1,6 +1,7 @@
 from __future__ import annotations
 
 import logging
+import sys
 from collections.abc import Callable, Iterator
 
 import pytest
@@ -46,6 +47,24 @@ def test_find_caller_skips_compiled_logging_extension_frame(
     assert c_caller == stdlib_caller
     assert c_caller[0] != fake_compiled_logging_path()
     assert stdlib_caller[0] != logging._srcfile
+
+
+@pytest.mark.skipif(
+    sys.version_info >= (3, 11),
+    reason="py3.10 uses the separate compiled findCaller frame helper",
+)
+def test_py310_find_caller_direct_call_reports_immediate_public_caller(
+    new_logger_pair: Callable[[int], object],
+) -> None:
+    pair = new_logger_pair(logging.DEBUG)
+
+    def user_frame() -> CallerInfo:
+        return pair.c_logger.findCaller()
+
+    filename, _lineno, func_name, _stack_info = user_frame()
+
+    assert func_name == "user_frame"
+    assert filename == __file__
 
 
 def test_public_emission_stacklevel_uses_user_frame_like_stdlib(


### PR DESCRIPTION
## Summary

Add a focused Python 3.10 logging parity guardrail that proves compiled `CLogger.findCaller()` reports the immediate public caller frame.

## Rationale

The existing parity tests compare CLogger and stdlib through symmetric helper stacks, which does not force a red/green failure for the py3.10 compiled direct `findCaller()` frame boundary. This test asserts the expected public caller explicitly so the bug is visible before applying the implementation fix.

## Details

- Adds a py3.10-only regression test for direct `CLogger.findCaller()`.
- Asserts the reported caller function is the immediate user frame.
- Leaves production code and generated artifacts untouched.

## Expected Result

This PR is expected to fail the Python 3.10 unit job until the implementation fix in #1211 is rebased on top.

## Testing

Expected red in CI:
- `Build And Test / unit (ubuntu-latest, 3.10)`
- likely also macOS/windows Python 3.10 unit jobs

Local proof on current master behavior:
- `PYTEST_DISABLE_PLUGIN_AUTOLOAD=1 uv run pytest tests/unit/logging/parity/test_caller.py::test_py310_find_caller_direct_call_reports_immediate_public_caller`
- Result: fails with `pytest_pyfunc_call` instead of `user_frame`