### PR TITLE
fix: preserve direct dispatch with native POA formatting

### DIFF
--- a/build/__native_internal_dank_mids.h
+++ b/build/__native_internal_dank_mids.h
@@ -6,7 +6,7 @@
 
 int CPyGlobalsInit(void);
 
-extern PyObject *CPyStatics[1545];
+extern PyObject *CPyStatics[1550];
 extern const char * const CPyLit_Str[];
 extern const char * const CPyLit_Bytes[];
 extern const char * const CPyLit_Int[];
@@ -131,8 +131,11 @@ extern PyObject *CPyStatic_formatters___globals;
 extern CPyModule *CPyModule_faster_eth_utils___curried;
 extern CPyModule *CPyModule_faster_eth_utils___toolz;
 extern CPyModule *CPyModule_hexbytes;
+extern CPyModule *CPyModule_msgspec;
+extern CPyModule *CPyModule_msgspec___json;
 extern CPyModule *CPyModule_web3____utils___method_formatters;
 extern CPyModule *CPyModule_web3____utils___rpc_abi;
+extern CPyModule *CPyModule_web3___datastructures;
 extern CPyModule *CPyModule_web3___types;
 extern int CPyExec_dank_mids____web3___formatters(PyObject *module);
 extern PyObject *CPyInit_dank_mids____web3___formatters(void);
@@ -229,9 +232,7 @@ extern int CPyExec_dank_mids___helpers(PyObject *module);
 extern PyObject *CPyInit_dank_mids___helpers(void);
 extern PyObject *CPyInitOnly_dank_mids___helpers(void);
 extern PyObject *CPyStatic__codec___globals;
-extern CPyModule *CPyModule_msgspec;
 extern CPyModule *CPyModule_faster_eth_abi___abi;
-extern CPyModule *CPyModule_msgspec___json;
 extern int CPyExec_dank_mids___helpers____codec(PyObject *module);
 extern PyObject *CPyInit_dank_mids___helpers____codec(void);
 extern PyObject *CPyInitOnly_dank_mids___helpers____codec(void);
@@ -288,7 +289,6 @@ extern int CPyExec_dank_mids___helpers___batch_size(PyObject *module);
 extern PyObject *CPyInit_dank_mids___helpers___batch_size(void);
 extern PyObject *CPyInitOnly_dank_mids___helpers___batch_size(void);
 extern PyObject *CPyStatic_hashing___globals;
-extern CPyModule *CPyModule_web3___datastructures;
 extern int CPyExec_dank_mids___helpers___hashing(PyObject *module);
 extern PyObject *CPyInit_dank_mids___helpers___hashing(void);
 extern PyObject *CPyInitOnly_dank_mids___helpers___hashing(void);

--- a/build/__native_internal_dank_mids.h
+++ b/build/__native_internal_dank_mids.h
@@ -6,7 +6,7 @@
 
 int CPyGlobalsInit(void);
 
-extern PyObject *CPyStatics[1534];
+extern PyObject *CPyStatics[1545];
 extern const char * const CPyLit_Str[];
 extern const char * const CPyLit_Bytes[];
 extern const char * const CPyLit_Int[];
@@ -130,6 +130,7 @@ extern CPyModule *CPyModule_dank_mids____web3___formatters;
 extern PyObject *CPyStatic_formatters___globals;
 extern CPyModule *CPyModule_faster_eth_utils___curried;
 extern CPyModule *CPyModule_faster_eth_utils___toolz;
+extern CPyModule *CPyModule_hexbytes;
 extern CPyModule *CPyModule_web3____utils___method_formatters;
 extern CPyModule *CPyModule_web3____utils___rpc_abi;
 extern CPyModule *CPyModule_web3___types;
@@ -589,6 +590,8 @@ extern PyObject *CPyStatic_formatters___ABI_REQUEST_FORMATTERS;
 extern tuple_T3OOO CPyStatic_formatters___REQUEST_FORMATTER_MAPS;
 extern PyObject *CPyStatic_formatters____request_formatters;
 extern PyObject *CPyStatic_formatters____response_formatters;
+extern PyObject *CPyStatic_formatters___POA_FORMATTER_METHODS;
+extern PyObject *CPyStatic_formatters____DANK_NULL_AS_RESULT_METHODS;
 extern PyTypeObject *CPyType_formatters___abi_request_formatters_gen;
 extern PyObject *CPyDef_formatters___abi_request_formatters_gen(void);
 extern CPyThreadLocal dank_mids____web3___formatters___abi_request_formatters_genObject *formatters___abi_request_formatters_gen_free_instance;
@@ -609,6 +612,10 @@ extern PyObject *CPyDef_formatters___abi_request_formatters(PyObject *cpy_r_norm
 extern PyObject *CPyPy_formatters___abi_request_formatters(PyObject *self, PyObject *const *args, size_t nargs, PyObject *kwnames);
 extern PyObject *CPyDef_formatters___get_request_formatters(PyObject *cpy_r_method_name);
 extern PyObject *CPyPy_formatters___get_request_formatters(PyObject *self, PyObject *const *args, size_t nargs, PyObject *kwnames);
+extern PyObject *CPyDef_formatters___dank_poa_result_formatter(PyObject *cpy_r_result);
+extern PyObject *CPyPy_formatters___dank_poa_result_formatter(PyObject *self, PyObject *const *args, size_t nargs, PyObject *kwnames);
+extern PyObject *CPyDef_formatters___get_dank_poa_result_formatter(PyObject *cpy_r_method);
+extern PyObject *CPyPy_formatters___get_dank_poa_result_formatter(PyObject *self, PyObject *const *args, size_t nargs, PyObject *kwnames);
 extern tuple_T3OOO CPyDef_formatters____get_response_formatters(PyObject *cpy_r_method);
 extern PyObject *CPyPy_formatters____get_response_formatters(PyObject *self, PyObject *const *args, size_t nargs, PyObject *kwnames);
 extern char CPyDef_formatters_____top_level__(void);

--- a/dank_mids/_web3/abi.py
+++ b/dank_mids/_web3/abi.py
@@ -89,7 +89,7 @@ class map_to_typed_data:
         elif not isinstance(elements, (bytes, str, bytearray)) and isinstance(elements, Iterable):
             return datatype(map(self, elements))
         elif isinstance(elements, ABITypedData) and elements.abi_type is not None:
-            return ABITypedData(*self.func(*elements))  # type: ignore [misc]
+            return ABITypedData(*self.func(elements.abi_type, elements.data))  # type: ignore [misc]
         else:
             return elements
 
@@ -148,6 +148,7 @@ def abi_sub_tree(abi_type: ABIType | None, data_value: Any) -> ABITypedData:
 
     # In the two special cases below, we rebuild the given data structures with
     # annotated items
+    value_to_annotate: Any
     if abi_type.is_array:
         # If type is array, determine item type and annotate all
         # items in iterable with that type

--- a/dank_mids/_web3/formatters.py
+++ b/dank_mids/_web3/formatters.py
@@ -1,9 +1,10 @@
-from collections.abc import Callable, Iterator, Sequence
+from collections.abc import Callable, Iterator, Mapping, Sequence
 from typing import Any, Final, TypeVar
 
 from eth_typing import TypeStr
 from faster_eth_utils.curried import apply_formatter_at_index  # type: ignore [attr-defined]
 from faster_eth_utils.toolz import compose
+from hexbytes import HexBytes
 from web3._utils.method_formatters import (
     ERROR_FORMATTERS,
     METHOD_NORMALIZERS,
@@ -11,7 +12,7 @@ from web3._utils.method_formatters import (
     PYTHONIC_REQUEST_FORMATTERS,
     STANDARD_NORMALIZERS,
 )
-from web3._utils.rpc_abi import RPC_ABIS, apply_abi_formatters_to_dict
+from web3._utils.rpc_abi import RPC, RPC_ABIS, apply_abi_formatters_to_dict
 from web3.types import Formatters, RPCEndpoint, RPCResponse
 
 from dank_mids._web3.abi import get_formatter
@@ -79,11 +80,47 @@ ResponseFormatters = tuple[SuccessFormatter, ErrorFormatter, NullFormatter]
 
 _response_formatters: Final[dict[RPCEndpoint, ResponseFormatters]] = {}
 
+POA_FORMATTER_METHODS: Final = frozenset(
+    (
+        RPC.eth_getBlockByHash,
+        RPC.eth_getBlockByNumber,
+        RPC.eth_subscribe,
+    )
+)
+
+_DANK_NULL_AS_RESULT_METHODS: Final = frozenset(
+    (
+        RPC.eth_getBlockByHash,
+        RPC.eth_getBlockByNumber,
+    )
+)
+
+
+def dank_poa_result_formatter(result: Any) -> Any:
+    if not isinstance(result, Mapping):
+        return result
+
+    if "extraData" not in result and "proofOfAuthorityData" not in result:
+        return result
+
+    formatted = dict(result)
+    if "extraData" in formatted:
+        formatted["proofOfAuthorityData"] = formatted.pop("extraData")
+    if formatted.get("proofOfAuthorityData") is not None:
+        formatted["proofOfAuthorityData"] = HexBytes(formatted["proofOfAuthorityData"])
+    return formatted
+
+
+def get_dank_poa_result_formatter(method: RPCEndpoint) -> SuccessFormatter:
+    return dank_poa_result_formatter if method in POA_FORMATTER_METHODS else return_as_is
+
 
 def _get_response_formatters(method: RPCEndpoint) -> ResponseFormatters:
     formatters = _response_formatters[method] = (
         return_as_is,
         ERROR_FORMATTERS.get(method, return_as_is),
-        NULL_RESULT_FORMATTERS.get(method, return_as_is),
+        return_as_is
+        if method in _DANK_NULL_AS_RESULT_METHODS
+        else NULL_RESULT_FORMATTERS.get(method, return_as_is),
     )
     return formatters

--- a/dank_mids/_web3/formatters.py
+++ b/dank_mids/_web3/formatters.py
@@ -5,6 +5,8 @@ from eth_typing import TypeStr
 from faster_eth_utils.curried import apply_formatter_at_index  # type: ignore [attr-defined]
 from faster_eth_utils.toolz import compose
 from hexbytes import HexBytes
+from msgspec import Raw
+from msgspec.json import decode as json_decode
 from web3._utils.method_formatters import (
     ERROR_FORMATTERS,
     METHOD_NORMALIZERS,
@@ -13,6 +15,7 @@ from web3._utils.method_formatters import (
     STANDARD_NORMALIZERS,
 )
 from web3._utils.rpc_abi import RPC, RPC_ABIS, apply_abi_formatters_to_dict
+from web3.datastructures import AttributeDict
 from web3.types import Formatters, RPCEndpoint, RPCResponse
 
 from dank_mids._web3.abi import get_formatter
@@ -97,6 +100,9 @@ _DANK_NULL_AS_RESULT_METHODS: Final = frozenset(
 
 
 def dank_poa_result_formatter(result: Any) -> Any:
+    if isinstance(result, Raw):
+        result = json_decode(result)
+
     if not isinstance(result, Mapping):
         return result
 
@@ -108,7 +114,7 @@ def dank_poa_result_formatter(result: Any) -> Any:
         formatted["proofOfAuthorityData"] = formatted.pop("extraData")
     if formatted.get("proofOfAuthorityData") is not None:
         formatted["proofOfAuthorityData"] = HexBytes(formatted["proofOfAuthorityData"])
-    return formatted
+    return AttributeDict.recursive(formatted)
 
 
 def get_dank_poa_result_formatter(method: RPCEndpoint) -> SuccessFormatter:

--- a/dank_mids/_web3/method.py
+++ b/dank_mids/_web3/method.py
@@ -19,7 +19,9 @@ from web3.types import RPCEndpoint, RPCResponse
 from dank_mids._web3.formatters import (
     _get_response_formatters,
     _response_formatters,
+    get_dank_poa_result_formatter,
     get_request_formatters,
+    return_as_is,
 )
 from dank_mids.helpers._controllers import get_controller_for_async_w3
 from dank_mids.types import Error, PartialResponse
@@ -125,8 +127,16 @@ def _middleware_allows_direct_dispatch(async_w3: Any) -> bool:
         return True
 
     from dank_mids.middleware import DankMiddleware
+    from web3.middleware import ExtraDataToPOAMiddleware
 
-    return all(middleware_class is DankMiddleware for middleware_class in middleware_classes)
+    compatible_middleware = (DankMiddleware, ExtraDataToPOAMiddleware)
+    return all(middleware_class in compatible_middleware for middleware_class in middleware_classes)
+
+
+def _middleware_applies_poa_formatting(async_w3: Any) -> bool:
+    from web3.middleware import ExtraDataToPOAMiddleware
+
+    return ExtraDataToPOAMiddleware in async_w3.middleware_onion.as_tuple_of_middleware()
 
 
 def retrieve_dank_method_call_fn(
@@ -158,10 +168,17 @@ def retrieve_dank_method_call_fn(
                 null_result_formatters,
             ) = response_formatters
             controller = get_controller_for_async_w3(async_w3)
-            response = await controller(cast(RPCEndpoint, method_str), params)
+            method_endpoint = cast(RPCEndpoint, method_str)
+            response = await controller(method_endpoint, params)
             result = _extract_dank_result(
                 response, params, error_formatters, null_result_formatters
             )
+            poa_result_formatter = (
+                get_dank_poa_result_formatter(method_endpoint)
+                if _middleware_applies_poa_formatting(async_w3)
+                else return_as_is
+            )
+            result = poa_result_formatter(result)
             return apply_result_formatters(result_formatters, result)
 
         return caller

--- a/dank_mids/_web3/method.py
+++ b/dank_mids/_web3/method.py
@@ -167,16 +167,21 @@ def retrieve_dank_method_call_fn(
                 error_formatters,
                 null_result_formatters,
             ) = response_formatters
-            controller = get_controller_for_async_w3(async_w3)
             method_endpoint = cast(RPCEndpoint, method_str)
-            response = await controller(method_endpoint, params)
-            result = _extract_dank_result(
-                response, params, error_formatters, null_result_formatters
-            )
             poa_result_formatter = (
                 get_dank_poa_result_formatter(method_endpoint)
                 if _middleware_applies_poa_formatting(async_w3)
                 else return_as_is
+            )
+            controller_method = (
+                cast(RPCEndpoint, f"{method_endpoint}_raw")
+                if poa_result_formatter is not return_as_is
+                else method_endpoint
+            )
+            controller = get_controller_for_async_w3(async_w3)
+            response = await controller(controller_method, params)
+            result = _extract_dank_result(
+                response, params, error_formatters, null_result_formatters
             )
             result = poa_result_formatter(result)
             return apply_result_formatters(result_formatters, result)

--- a/dank_mids/helpers/_helpers.py
+++ b/dank_mids/helpers/_helpers.py
@@ -72,9 +72,14 @@ def setup_dank_w3(async_w3: Web3) -> DankWeb3:
         # NOTE: We import here to prevent a circular import
         from dank_mids.middleware import DankMiddleware
 
-        if _sync_w3_from_async(async_w3).eth.chain_id not in skip_poa_middleware:
-            async_w3.middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
-        async_w3.middleware_onion.inject(DankMiddleware, layer=0)
+        middleware_onion = async_w3.middleware_onion
+        if (
+            _sync_w3_from_async(async_w3).eth.chain_id not in skip_poa_middleware
+            and ExtraDataToPOAMiddleware not in middleware_onion
+        ):
+            middleware_onion.inject(ExtraDataToPOAMiddleware, layer=0)
+        if DankMiddleware not in middleware_onion:
+            middleware_onion.inject(DankMiddleware, layer=0)
         dank_w3s.append(async_w3)
     async_w3.eth = DankEth(async_w3)
     return async_w3

--- a/tests/unit/test_dank_eth_direct_dispatch.py
+++ b/tests/unit/test_dank_eth_direct_dispatch.py
@@ -7,6 +7,7 @@ from types import SimpleNamespace
 from typing import Any, ClassVar
 
 from eth_abi import encode
+from hexbytes import HexBytes
 import pytest
 from web3 import AsyncWeb3
 from web3._utils.error_formatters_utils import OFFCHAIN_LOOKUP_FUNC_SELECTOR
@@ -14,13 +15,17 @@ from web3._utils.rpc_abi import RPC
 from web3.eth import AsyncEth
 from web3.exceptions import OffchainLookup
 from web3.method import Method
+from web3.middleware import ExtraDataToPOAMiddleware
 from web3.middleware.base import Web3Middleware
 from web3.types import RPCEndpoint, RPCResponse
 
 import dank_mids
+import dank_mids._web3.formatters as formatter_module
+import dank_mids._web3.method as method_module
 import dank_mids.controller as controller_module
 import dank_mids.helpers._controllers as controller_cache_module
 import dank_mids.helpers._helpers as helpers
+from dank_mids._exceptions import ExecutionReverted
 from dank_mids.helpers import _requester as requester_module
 import dank_mids.middleware as middleware
 from dank_mids.eth import DankEth
@@ -47,6 +52,18 @@ class _NoopAsyncContext:
 class _NoopSemaphores:
     def __getitem__(self, block: Any) -> _NoopAsyncContext:
         return _NoopAsyncContext()
+
+
+class _RecordingDirectController:
+    def __init__(self, *responses: RPCResponse) -> None:
+        self.responses = list(responses)
+        self.calls: list[tuple[RPCEndpoint, Any]] = []
+
+    async def __call__(self, method: RPCEndpoint, params: Any) -> RPCResponse:
+        self.calls.append((method, params))
+        if len(self.responses) > 1:
+            return self.responses.pop(0)
+        return self.responses[0]
 
 
 @dataclass(frozen=True)
@@ -139,6 +156,13 @@ def _install_inert_controller_init(monkeypatch: pytest.MonkeyPatch) -> None:
     monkeypatch.setattr(controller_module, "_get_client_version", lambda _sync_w3: "pytest/test")
     monkeypatch.setattr(controller_module, "_get_multicall2", lambda _chainid: fake_multicall)
     monkeypatch.setattr(controller_module, "_get_multicall3", lambda _chainid: None)
+
+
+def _install_direct_controller(
+    monkeypatch: pytest.MonkeyPatch,
+    controller: _RecordingDirectController,
+) -> None:
+    monkeypatch.setattr(method_module, "get_controller_for_async_w3", lambda _w3: controller)
 
 
 def _process_param_cases() -> list[_ProcessParamsCase]:
@@ -357,6 +381,272 @@ def test_dank_eth_direct_dispatch_allows_dank_middleware_only(
         }
 
     asyncio.run(run())
+
+
+def test_direct_dispatch_contract_accepts_result_only_response_for_mainnet_and_poa_clients(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Mainnet and POA clients accept the same result-only Dank response contract."""
+
+    async def run() -> None:
+        for middleware_classes in (
+            (),
+            (ExtraDataToPOAMiddleware, middleware.DankMiddleware),
+        ):
+            async_w3, eth = _new_dank_eth()
+            for middleware_class in middleware_classes:
+                async_w3.middleware_onion.add(middleware_class)
+            controller = _RecordingDirectController({"result": 123})
+            _install_direct_controller(monkeypatch, controller)
+            _forbid_web3_manager(monkeypatch, async_w3)
+
+            assert await eth.get_block_number() == 123
+            assert controller.calls == [(RPC.eth_blockNumber, ())]
+
+    asyncio.run(run())
+
+
+def test_direct_dispatch_contract_accepts_standard_jsonrpc_response(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct dispatch still accepts complete JSON-RPC envelopes."""
+
+    async def run() -> None:
+        async_w3, eth = _new_dank_eth()
+        controller = _RecordingDirectController({"jsonrpc": "2.0", "id": 1, "result": 456})
+        _install_direct_controller(monkeypatch, controller)
+        _forbid_web3_manager(monkeypatch, async_w3)
+
+        assert await eth.get_block_number() == 456
+        assert controller.calls == [(RPC.eth_blockNumber, ())]
+
+    asyncio.run(run())
+
+
+def test_direct_dispatch_contract_preserves_dank_error_handling(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct dispatch keeps existing Dank error conversion for error responses."""
+
+    async def run() -> None:
+        async_w3, eth = _new_dank_eth()
+        controller = _RecordingDirectController(
+            {"error": {"code": 3, "message": "execution reverted"}}
+        )
+        _install_direct_controller(monkeypatch, controller)
+        _forbid_web3_manager(monkeypatch, async_w3)
+
+        with pytest.raises(ExecutionReverted):
+            await eth.get_block_number()
+
+        assert controller.calls == [(RPC.eth_blockNumber, ())]
+
+    asyncio.run(run())
+
+
+def test_poa_direct_dispatch_does_not_call_web3_manager_for_method_no_format(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POA middleware no longer routes Dank-owned methods through Web3 validation."""
+
+    async def run() -> None:
+        async_w3, eth = _new_dank_eth()
+        async_w3.middleware_onion.add(ExtraDataToPOAMiddleware)
+        async_w3.middleware_onion.add(middleware.DankMiddleware)
+        controller = _RecordingDirectController({"result": 789})
+        _install_direct_controller(monkeypatch, controller)
+        _forbid_web3_manager(monkeypatch, async_w3)
+
+        assert await eth.get_block_number() == 789
+        assert controller.calls == [(RPC.eth_blockNumber, ())]
+
+    asyncio.run(run())
+
+
+def test_direct_dispatch_poa_formats_get_block_by_number_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POA cleanup runs on direct eth_getBlockByNumber results."""
+
+    async def run() -> None:
+        async_w3, eth = _new_dank_eth()
+        async_w3.middleware_onion.add(ExtraDataToPOAMiddleware)
+        controller = _RecordingDirectController(
+            {"result": {"number": "0x1", "extraData": "0x1234"}}
+        )
+        _install_direct_controller(monkeypatch, controller)
+        _forbid_web3_manager(monkeypatch, async_w3)
+
+        block = await eth.get_block(1)
+
+        assert controller.calls == [(RPC.eth_getBlockByNumber, ("0x1", False))]
+        assert "extraData" not in block
+        assert block["proofOfAuthorityData"] == HexBytes("0x1234")
+
+    asyncio.run(run())
+
+
+def test_direct_dispatch_poa_formats_get_block_by_hash_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POA cleanup runs on direct eth_getBlockByHash results."""
+
+    async def run() -> None:
+        block_hash = HexBytes("0x" + "12" * 32)
+        async_w3, eth = _new_dank_eth()
+        async_w3.middleware_onion.add(ExtraDataToPOAMiddleware)
+        controller = _RecordingDirectController(
+            {"result": {"number": "0x1", "extraData": "0x5678"}}
+        )
+        _install_direct_controller(monkeypatch, controller)
+        _forbid_web3_manager(monkeypatch, async_w3)
+
+        block = await eth.get_block(block_hash)
+
+        assert controller.calls == [(RPC.eth_getBlockByHash, [block_hash.to_0x_hex(), False])]
+        assert "extraData" not in block
+        assert block["proofOfAuthorityData"] == HexBytes("0x5678")
+
+    asyncio.run(run())
+
+
+def test_direct_dispatch_poa_leaves_null_block_result_none(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POA cleanup leaves null block results as None."""
+
+    async def run() -> None:
+        async_w3, eth = _new_dank_eth()
+        async_w3.middleware_onion.add(ExtraDataToPOAMiddleware)
+        controller = _RecordingDirectController({"result": None})
+        _install_direct_controller(monkeypatch, controller)
+        _forbid_web3_manager(monkeypatch, async_w3)
+
+        assert await eth.get_block(1) is None
+        assert controller.calls == [(RPC.eth_getBlockByNumber, ("0x1", False))]
+
+    asyncio.run(run())
+
+
+def test_direct_dispatch_poa_preserves_already_normalized_block_result(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POA cleanup preserves already-normalized proofOfAuthorityData payloads."""
+
+    async def run() -> None:
+        async_w3, eth = _new_dank_eth()
+        async_w3.middleware_onion.add(ExtraDataToPOAMiddleware)
+        controller = _RecordingDirectController(
+            {"result": {"number": "0x1", "proofOfAuthorityData": "0xabcd"}}
+        )
+        _install_direct_controller(monkeypatch, controller)
+        _forbid_web3_manager(monkeypatch, async_w3)
+
+        block = await eth.get_block(1)
+
+        assert "extraData" not in block
+        assert block["proofOfAuthorityData"] == HexBytes("0xabcd")
+
+    asyncio.run(run())
+
+
+def test_direct_dispatch_applies_result_formatter_once(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """POA result formatting is applied exactly once per direct response."""
+
+    async def run() -> None:
+        async_w3, eth = _new_dank_eth()
+        async_w3.middleware_onion.add(ExtraDataToPOAMiddleware)
+        controller = _RecordingDirectController(
+            {"result": {"number": "0x1", "extraData": "0x1234"}}
+        )
+        calls: list[RPCEndpoint] = []
+        original_getter = method_module.get_dank_poa_result_formatter
+
+        def counting_getter(method: RPCEndpoint):
+            formatter = original_getter(method)
+
+            def count_and_format(result: Any) -> Any:
+                calls.append(method)
+                return formatter(result)
+
+            return count_and_format
+
+        monkeypatch.setattr(method_module, "get_dank_poa_result_formatter", counting_getter)
+        _install_direct_controller(monkeypatch, controller)
+        _forbid_web3_manager(monkeypatch, async_w3)
+
+        block = await eth.get_block(1)
+
+        assert calls == [RPC.eth_getBlockByNumber]
+        assert block["proofOfAuthorityData"] == HexBytes("0x1234")
+
+    asyncio.run(run())
+
+
+def test_direct_dispatch_makes_one_controller_request_for_poa_method(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Direct POA dispatch does not introduce duplicate RPC requests."""
+
+    async def run() -> None:
+        async_w3, eth = _new_dank_eth()
+        async_w3.middleware_onion.add(ExtraDataToPOAMiddleware)
+        controller = _RecordingDirectController(
+            {"result": {"number": "0x1", "extraData": "0x1234"}}
+        )
+        _install_direct_controller(monkeypatch, controller)
+        _forbid_web3_manager(monkeypatch, async_w3)
+
+        await eth.get_block(1)
+
+        assert controller.calls == [(RPC.eth_getBlockByNumber, ("0x1", False))]
+
+    asyncio.run(run())
+
+
+def test_direct_dispatch_allows_only_dank_compatible_middleware(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Only Dank and POA middleware preserve the direct-dispatch invariant."""
+
+    class PassthroughMiddleware(Web3Middleware):
+        pass
+
+    async def run() -> None:
+        poa_w3, poa_eth = _new_dank_eth()
+        poa_w3.middleware_onion.add(ExtraDataToPOAMiddleware)
+        poa_w3.middleware_onion.add(middleware.DankMiddleware)
+        poa_controller = _RecordingDirectController({"result": 123})
+        _install_direct_controller(monkeypatch, poa_controller)
+        _forbid_web3_manager(monkeypatch, poa_w3)
+
+        assert await poa_eth.get_block_number() == 123
+        assert poa_controller.calls == [(RPC.eth_blockNumber, ())]
+
+        provider = AsyncProvider(response={"jsonrpc": "2.0", "id": 1, "result": "0x7b"})
+        fallback_w3 = AsyncWeb3(provider)
+        fallback_w3.middleware_onion.clear()
+        fallback_w3.middleware_onion.add(PassthroughMiddleware)
+        fallback_eth = DankEth(fallback_w3)
+
+        assert await fallback_eth.get_block_number() == "0x7b"
+        assert provider.calls == [(RPC.eth_blockNumber, ())]
+
+    asyncio.run(run())
+
+
+def test_dank_poa_subscription_formatter_preserves_ids_and_formats_block_payloads() -> None:
+    """The Dank POA subscription formatter preserves ids and formats block payloads."""
+
+    formatter = formatter_module.get_dank_poa_result_formatter(RPC.eth_subscribe)
+
+    assert formatter("0xsubscription") == "0xsubscription"
+    assert formatter({"number": "0x1", "extraData": "0x1234"}) == {
+        "number": "0x1",
+        "proofOfAuthorityData": HexBytes("0x1234"),
+    }
 
 
 def test_inherited_syncing_falls_back_to_web3_caller(

--- a/tests/unit/test_dank_eth_direct_dispatch.py
+++ b/tests/unit/test_dank_eth_direct_dispatch.py
@@ -39,6 +39,31 @@ from tests.unit._jsonrpc import (
 
 ACCOUNT = "0x0000000000000000000000000000000000000001"
 OTHER_ACCOUNT = "0x0000000000000000000000000000000000000002"
+ZERO_HASH = "0x" + "00" * 32
+ZERO_ADDRESS = "0x" + "00" * 20
+
+
+def _jsonrpc_block(extra_data: str = "0x1234") -> dict[str, Any]:
+    return {
+        "timestamp": "0x1",
+        "transactions": [],
+        "number": "0x1",
+        "hash": ZERO_HASH,
+        "logsBloom": "0x00",
+        "receiptsRoot": ZERO_HASH,
+        "extraData": extra_data,
+        "nonce": "0x0000000000000000",
+        "miner": ZERO_ADDRESS,
+        "gasLimit": "0x1",
+        "gasUsed": "0x0",
+        "uncles": [],
+        "sha3Uncles": ZERO_HASH,
+        "size": "0x1",
+        "transactionsRoot": ZERO_HASH,
+        "stateRoot": ZERO_HASH,
+        "mixHash": ZERO_HASH,
+        "parentHash": ZERO_HASH,
+    }
 
 
 class _NoopAsyncContext:
@@ -479,7 +504,9 @@ def test_direct_dispatch_poa_formats_get_block_by_number_result(
 
         block = await eth.get_block(1)
 
-        assert controller.calls == [(RPC.eth_getBlockByNumber, ("0x1", False))]
+        assert controller.calls == [
+            (RPCEndpoint(f"{RPC.eth_getBlockByNumber}_raw"), ("0x1", False))
+        ]
         assert "extraData" not in block
         assert block["proofOfAuthorityData"] == HexBytes("0x1234")
 
@@ -503,7 +530,9 @@ def test_direct_dispatch_poa_formats_get_block_by_hash_result(
 
         block = await eth.get_block(block_hash)
 
-        assert controller.calls == [(RPC.eth_getBlockByHash, [block_hash.to_0x_hex(), False])]
+        assert controller.calls == [
+            (RPCEndpoint(f"{RPC.eth_getBlockByHash}_raw"), [block_hash.to_0x_hex(), False])
+        ]
         assert "extraData" not in block
         assert block["proofOfAuthorityData"] == HexBytes("0x5678")
 
@@ -523,7 +552,37 @@ def test_direct_dispatch_poa_leaves_null_block_result_none(
         _forbid_web3_manager(monkeypatch, async_w3)
 
         assert await eth.get_block(1) is None
-        assert controller.calls == [(RPC.eth_getBlockByNumber, ("0x1", False))]
+        assert controller.calls == [
+            (RPCEndpoint(f"{RPC.eth_getBlockByNumber}_raw"), ("0x1", False))
+        ]
+
+    asyncio.run(run())
+
+
+def test_direct_dispatch_poa_formats_raw_controller_block_before_decode(
+    monkeypatch: pytest.MonkeyPatch,
+    controller_cache: dict[tuple[AsyncWeb3, threading.Thread], Any],
+    jsonrpc_server: JsonRpcServer,
+) -> None:
+    """Real Dank controller responses are cleaned before evmspec block decoding."""
+
+    async def run() -> None:
+        extra_data = "0x" + "12" * 33
+        jsonrpc_server.results[RPC.eth_getBlockByNumber] = _jsonrpc_block(extra_data)
+        async_w3, eth = _new_dank_eth(server_endpoint(jsonrpc_server))
+        async_w3.middleware_onion.add(ExtraDataToPOAMiddleware)
+        _forbid_web3_manager(monkeypatch, async_w3)
+
+        block = await eth.get_block(1)
+
+        assert (RPC.eth_getBlockByNumber, ["0x1", False]) in jsonrpc_server.calls
+        assert isinstance(
+            controller_cache[(async_w3, threading.current_thread())],
+            controller_module.DankMiddlewareController,
+        )
+        assert "extraData" not in block
+        assert block["proofOfAuthorityData"] == HexBytes(extra_data)
+        assert block.proofOfAuthorityData == HexBytes(extra_data)
 
     asyncio.run(run())
 
@@ -601,7 +660,9 @@ def test_direct_dispatch_makes_one_controller_request_for_poa_method(
 
         await eth.get_block(1)
 
-        assert controller.calls == [(RPC.eth_getBlockByNumber, ("0x1", False))]
+        assert controller.calls == [
+            (RPCEndpoint(f"{RPC.eth_getBlockByNumber}_raw"), ("0x1", False))
+        ]
 
     asyncio.run(run())
 

--- a/tests/unit/test_web3_v7_async_middleware.py
+++ b/tests/unit/test_web3_v7_async_middleware.py
@@ -153,6 +153,58 @@ def test_non_mainnet_setup_injects_web3_v7_poa_middleware_before_dank(monkeypatc
         helpers.dank_w3s.clear()
 
 
+def test_non_mainnet_setup_skips_existing_async_poa_and_dank_middleware(monkeypatch) -> None:
+    """Async setup is idempotent when POA and Dank middleware are already installed."""
+    dank_eth = object()
+    async_w3 = SimpleNamespace(
+        eth=SimpleNamespace(is_async=True),
+        provider=_AsyncProvider(),
+        middleware_onion=_RecordingOnion(
+            existing=(ExtraDataToPOAMiddleware, middleware.DankMiddleware)
+        ),
+    )
+    monkeypatch.setattr(dank_mids, "_ensure_side_effects", lambda: None)
+    monkeypatch.setattr(helpers, "DankEth", lambda _async_w3: dank_eth)
+    monkeypatch.setattr(
+        helpers,
+        "_sync_w3_from_async",
+        lambda _async_w3: SimpleNamespace(eth=SimpleNamespace(chain_id=137)),
+    )
+    try:
+        helpers.dank_w3s.clear()
+        helpers.setup_dank_w3(async_w3)
+
+        assert async_w3.middleware_onion.inject_calls == []
+        assert async_w3.eth is dank_eth
+    finally:
+        helpers.dank_w3s.clear()
+
+
+def test_non_mainnet_setup_injects_only_missing_async_dank_middleware(monkeypatch) -> None:
+    """Async setup preserves existing POA middleware and adds missing Dank middleware."""
+    dank_eth = object()
+    async_w3 = SimpleNamespace(
+        eth=SimpleNamespace(is_async=True),
+        provider=_AsyncProvider(),
+        middleware_onion=_RecordingOnion(existing=(ExtraDataToPOAMiddleware,)),
+    )
+    monkeypatch.setattr(dank_mids, "_ensure_side_effects", lambda: None)
+    monkeypatch.setattr(helpers, "DankEth", lambda _async_w3: dank_eth)
+    monkeypatch.setattr(
+        helpers,
+        "_sync_w3_from_async",
+        lambda _async_w3: SimpleNamespace(eth=SimpleNamespace(chain_id=137)),
+    )
+    try:
+        helpers.dank_w3s.clear()
+        helpers.setup_dank_w3(async_w3)
+
+        assert async_w3.middleware_onion.inject_calls == [(middleware.DankMiddleware, 0)]
+        assert async_w3.eth is dank_eth
+    finally:
+        helpers.dank_w3s.clear()
+
+
 def test_dank_middleware_attribute_raises_migration_error() -> None:
     with pytest.raises(ImportError) as exc_info:
         getattr(middleware, "dank_middleware")


### PR DESCRIPTION
Keep Dank-owned RPC methods off strict Web3 validation on POA chains while retaining block normalization.