### PR TITLE
fix: make MethodNoFormat generic for mypy

### DIFF
--- a/dank_mids/_web3/method.py
+++ b/dank_mids/_web3/method.py
@@ -1,5 +1,5 @@
 from collections.abc import Callable, Coroutine
-from typing import Any, cast
+from typing import Any, Generic, cast
 
 from typing_extensions import Self
 from web3._utils.blocks import select_method_for_block_identifier
@@ -27,7 +27,7 @@ from dank_mids.helpers._controllers import get_controller_for_async_w3
 from dank_mids.types import Error, PartialResponse
 
 
-class MethodNoFormat(Method[TFunc]):
+class MethodNoFormat(Method[TFunc], Generic[TFunc]):
     """Custom method class to bypass web3py's default result formatters.
 
     This class processes parameters, makes conditional adjustments to the parameters,


### PR DESCRIPTION
## Summary

- Makes `MethodNoFormat` explicitly generic over Web3's existing `TFunc`.
- Leaves the `DankEth` method annotations and runtime formatter/dispatch behavior unchanged.

## Rationale

Mypy was reporting that `MethodNoFormat` expected no type arguments at the `DankEth` annotations in `dank_mids/eth.py`. The cleanest fix is to make the wrapper class itself explicitly generic instead of weakening the call-site annotations or adding broad ignores.

## Details

- Imports `Generic` from `typing` in `dank_mids/_web3/method.py`.
- Changes `MethodNoFormat` from `Method[TFunc]` to `Method[TFunc], Generic[TFunc]`.
- Validation: `git diff --check` passed.
- Validation not run: `uv run --no-sync mypy dank_mids/eth.py dank_mids/_web3/method.py` could not run in the local shell because `uv` is unavailable (`uv: command not found`).